### PR TITLE
feat(cli): add arrow-up input history navigation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,8 +2,13 @@
 
 All coding guidelines, commit conventions, architecture principles, and
 development workflows are documented in [`AGENTS.md`](../AGENTS.md) at the
-repo root. Please read that file for the full set of instructions.
+repo root. That file is the authoritative source for the full set of
+instructions.
 
+The remainder of this document is a curated quick-reference subset of
+those rules, optimized for Copilot and reviewers. It must be kept in
+sync with `AGENTS.md` and must not introduce any new or conflicting
+requirements.
 
 Format: `<type>(<optional scope>): <short imperative description>`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
-# Copilot instructions for curraint
+# Agent instructions for curraint
 
-All coding guidelines, commit conventions, architecture principles, and
-development workflows are documented in [`AGENTS.md`](../AGENTS.md) at the
-repo root. Please read that file for the full set of instructions.
+## Commit messages
 
+Always follow [Conventional Commits](https://www.conventionalcommits.org/).
 
 Format: `<type>(<optional scope>): <short imperative description>`
 
@@ -94,3 +93,28 @@ This is a pnpm monorepo. All packages live under `packages/`.
 - Small, single-purpose functions with descriptive names.
 - Unit tests live alongside source files as `*.test.ts`.
 - All tests must pass before a PR is merged (`pnpm test`).
+
+## Feature development workflow (Red - Green - Refactor)
+
+Follow the TDD red-green-refactor cycle for all new features and non-trivial bug fixes.
+
+**Red** - write failing tests first
+- Write all unit tests for the new behaviour before writing any implementation.
+- Tests must reference the not-yet-existing module/class/function so they fail with an import or "does not exist" error - confirming the test runner actually executes them.
+- Cover the happy path, edge cases, and any documented constraints (e.g. de-dup rules, boundary conditions).
+- Run the test suite and confirm every new test fails.
+
+**Green** - make the tests pass with the simplest correct implementation
+- Write only enough code to make all failing tests pass.
+- Do not add behaviour that has no corresponding test.
+- Re-run the suite after implementing - all tests (new and existing) must be green before moving on.
+
+**Refactor** - clean up without changing behaviour
+- Review all changed files for duplication, naming consistency, and unnecessary complexity.
+- Extract helpers or types only if they genuinely simplify the code - do not over-engineer.
+- Run the full test suite again after every refactor step to confirm nothing regressed.
+
+**Practical rules**
+- New logic that can be unit tested in isolation (e.g. a class, a pure function, a parser) must live in its own file and have a dedicated `*.test.ts` sibling.
+- Logic that only orchestrates side effects (wiring modules together in `run.ts`, IPC handlers, etc.) does not need unit tests but must be covered by the integration or e2e suite where feasible.
+- Never skip the Red phase - writing tests after the implementation defeats the purpose.

--- a/packages/cli/src/input-history.test.ts
+++ b/packages/cli/src/input-history.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InputHistory } from './input-history';
+
+describe('InputHistory', () => {
+  let history: InputHistory;
+
+  beforeEach(() => {
+    history = new InputHistory();
+  });
+
+  describe('push', () => {
+    it('adds an entry that can be retrieved by navigateBack', () => {
+      history.push('hello');
+      expect(history.navigateBack('')).toBe('hello');
+    });
+
+    it('ignores empty strings', () => {
+      history.push('');
+      expect(history.navigateBack('')).toBeUndefined();
+    });
+
+    it('de-dupes consecutive identical entries', () => {
+      history.push('hello');
+      history.push('hello');
+      history.push('hello');
+      expect(history.navigateBack('')).toBe('hello');
+      // Only one entry - navigating further should return undefined
+      expect(history.navigateBack('')).toBeUndefined();
+    });
+
+    it('allows non-consecutive duplicates', () => {
+      history.push('hello');
+      history.push('world');
+      history.push('hello');
+      history.navigateBack(''); // hello (latest)
+      history.navigateBack(''); // world
+      expect(history.navigateBack('')).toBe('hello'); // oldest
+    });
+  });
+
+  describe('navigateBack', () => {
+    it('returns undefined when history is empty', () => {
+      expect(history.navigateBack('')).toBeUndefined();
+    });
+
+    it('returns newest entry first', () => {
+      history.push('first');
+      history.push('second');
+      history.push('third');
+      expect(history.navigateBack('')).toBe('third');
+    });
+
+    it('returns older entries on repeated calls', () => {
+      history.push('first');
+      history.push('second');
+      history.push('third');
+      history.navigateBack('');
+      history.navigateBack('');
+      expect(history.navigateBack('')).toBe('first');
+    });
+
+    it('stays at oldest entry and returns undefined instead of wrapping', () => {
+      history.push('only');
+      history.navigateBack('');
+      expect(history.navigateBack('')).toBeUndefined();
+    });
+
+    it('saves the current draft on the first call', () => {
+      history.push('previous');
+      history.navigateBack('my draft');
+      expect(history.navigateForward()).toBe('my draft');
+    });
+  });
+
+  describe('navigateForward', () => {
+    it('returns undefined when not navigating', () => {
+      expect(history.navigateForward()).toBeUndefined();
+    });
+
+    it('returns a more-recent entry when in the middle of history', () => {
+      history.push('first');
+      history.push('second');
+      history.push('third');
+      history.navigateBack(''); // third
+      history.navigateBack(''); // second
+      expect(history.navigateForward()).toBe('third');
+    });
+
+    it('restores the saved draft when reaching the live position', () => {
+      history.push('previous');
+      history.navigateBack('in progress');
+      expect(history.navigateForward()).toBe('in progress');
+    });
+
+    it('returns undefined on further calls once draft is returned', () => {
+      history.push('previous');
+      history.navigateBack('draft');
+      history.navigateForward(); // returns draft (live position)
+      expect(history.navigateForward()).toBeUndefined();
+    });
+  });
+
+  describe('isNavigating', () => {
+    it('is false initially', () => {
+      expect(history.isNavigating).toBe(false);
+    });
+
+    it('becomes true after navigateBack', () => {
+      history.push('msg');
+      history.navigateBack('');
+      expect(history.isNavigating).toBe(true);
+    });
+
+    it('becomes false again after navigating fully forward', () => {
+      history.push('msg');
+      history.navigateBack('');
+      history.navigateForward(); // returns draft - back at live position
+      expect(history.isNavigating).toBe(false);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears navigation state so next browse starts fresh', () => {
+      history.push('first');
+      history.push('second');
+      history.navigateBack(''); // second
+      history.reset();
+      expect(history.isNavigating).toBe(false);
+      // After reset, navigateBack should start from newest again
+      expect(history.navigateBack('')).toBe('second');
+    });
+
+    it('clears the saved draft', () => {
+      history.push('msg');
+      history.navigateBack('my draft');
+      history.reset();
+      history.navigateBack('');
+      history.navigateForward(); // back to live
+      expect(history.navigateForward()).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/input-history.ts
+++ b/packages/cli/src/input-history.ts
@@ -1,0 +1,54 @@
+export class InputHistory {
+  private entries: string[] = [];
+  private historyIndex = -1;
+  private draftBuf = '';
+
+  push(entry: string): void {
+    if (!entry) return;
+    if (this.entries.length > 0 && this.entries[this.entries.length - 1] === entry) return;
+    this.entries.push(entry);
+  }
+
+  /**
+   * Navigate backwards (older). On the first call, saves currentBuf as the
+   * draft so it can be restored when navigating forward past the newest entry.
+   * Returns the entry to display, or undefined if there are no entries or
+   * the oldest entry has already been reached.
+   */
+  navigateBack(currentBuf: string): string | undefined {
+    if (this.entries.length === 0) return undefined;
+    if (this.historyIndex === -1) {
+      this.draftBuf = currentBuf;
+    }
+    const nextIndex = this.historyIndex + 1;
+    if (nextIndex >= this.entries.length) return undefined;
+    this.historyIndex = nextIndex;
+    return this.entries[this.entries.length - 1 - this.historyIndex];
+  }
+
+  /**
+   * Navigate forwards (newer). When reaching the live position (index -1),
+   * returns the saved draft. Returns undefined when already at the live
+   * position with no unsaved draft.
+   */
+  navigateForward(): string | undefined {
+    if (this.historyIndex === -1) return undefined;
+    this.historyIndex -= 1;
+    if (this.historyIndex === -1) {
+      const draft = this.draftBuf;
+      this.draftBuf = '';
+      return draft;
+    }
+    return this.entries[this.entries.length - 1 - this.historyIndex];
+  }
+
+  /** Resets navigation cursor so the next browse starts from the newest entry. */
+  reset(): void {
+    this.historyIndex = -1;
+    this.draftBuf = '';
+  }
+
+  get isNavigating(): boolean {
+    return this.historyIndex !== -1;
+  }
+}

--- a/packages/cli/src/input-history.ts
+++ b/packages/cli/src/input-history.ts
@@ -3,6 +3,7 @@ export class InputHistory {
   private historyIndex = -1;
   private draftBuf = '';
 
+  /** Appends entry to history. Ignores empty strings and consecutive duplicates. */
   push(entry: string): void {
     if (!entry) return;
     if (this.entries.length > 0 && this.entries[this.entries.length - 1] === entry) return;
@@ -48,6 +49,7 @@ export class InputHistory {
     this.draftBuf = '';
   }
 
+  /** True while the user is browsing history; false when at the live input position. */
   get isNavigating(): boolean {
     return this.historyIndex !== -1;
   }

--- a/packages/cli/src/input-history.ts
+++ b/packages/cli/src/input-history.ts
@@ -1,5 +1,5 @@
 export class InputHistory {
-  private entries: string[] = [];
+  private readonly entries: string[] = [];
   private historyIndex = -1;
   private draftBuf = '';
 

--- a/packages/cli/src/readline-completion.ts
+++ b/packages/cli/src/readline-completion.ts
@@ -1,6 +1,7 @@
 import readline from 'node:readline/promises';
 import { stdout as output } from 'node:process';
 import { c } from './theme';
+import type { InputHistory } from './input-history';
 
 export const SLASH_COMMANDS: Array<{ command: string; description: string; requiresArg?: boolean }> = [
   { command: '/help',     description: 'Show commands' },
@@ -22,7 +23,7 @@ export const SLASH_COMMANDS: Array<{ command: string; description: string; requi
  * keys and accepting with Tab or Enter. Falls back to plain readline in
  * non-TTY (piped) environments.
  */
-export async function readLineWithCompletion(rl: readline.Interface, prompt: string): Promise<string> {
+export async function readLineWithCompletion(rl: readline.Interface, prompt: string, history?: InputHistory): Promise<string> {
   const stdin = process.stdin as NodeJS.ReadStream;
   if (!stdin.isTTY) {
     return rl.question(prompt);
@@ -99,12 +100,22 @@ export async function readLineWithCompletion(rl: readline.Interface, prompt: str
         if (suggestions.length > 0) {
           selectedIdx = (selectedIdx - 1 + suggestions.length) % suggestions.length;
           redraw();
+        } else if (history) {
+          const entry = history.navigateBack(buf);
+          if (entry !== undefined) {
+            buf = entry;
+            redraw();
+          }
         }
         return;
       }
       if (char === '\x1b[B') { // Down arrow
         if (suggestions.length > 0) {
           selectedIdx = (selectedIdx + 1) % suggestions.length;
+          redraw();
+        } else if (history) {
+          const entry = history.navigateForward();
+          buf = entry ?? '';
           redraw();
         }
         return;
@@ -124,6 +135,7 @@ export async function readLineWithCompletion(rl: readline.Interface, prompt: str
             }
           }
           stdin.removeListener('data', onData);
+          history?.reset();
           cleanup();
           resolve(buf);
           break;

--- a/packages/cli/src/readline-completion.ts
+++ b/packages/cli/src/readline-completion.ts
@@ -115,8 +115,10 @@ export async function readLineWithCompletion(rl: readline.Interface, prompt: str
           redraw();
         } else if (history) {
           const entry = history.navigateForward();
-          buf = entry ?? '';
-          redraw();
+          if (entry !== undefined) {
+            buf = entry;
+            redraw();
+          }
         }
         return;
       }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -20,6 +20,7 @@ import { dispatchSlashCommand } from './commands/registry';
 import type { CommandContext } from './commands/types';
 import { InputHistory } from './input-history';
 
+/** Starts the interactive CLI chat loop. Returns an exit code (0 on clean exit, 1 on setup failure). */
 export async function run(): Promise<number> {
   let settings = loadSettings();
   const rl = readline.createInterface({ input, output });

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -18,6 +18,7 @@ import { readLineWithCompletion } from './readline-completion';
 import { SessionUI } from './session-ui';
 import { dispatchSlashCommand } from './commands/registry';
 import type { CommandContext } from './commands/types';
+import { InputHistory } from './input-history';
 
 export async function run(): Promise<number> {
   let settings = loadSettings();
@@ -79,10 +80,13 @@ export async function run(): Promise<number> {
   });
 
   try {
+    const history = new InputHistory();
     while (true) {
       output.write(`\n${divider()}\n`);
-      const text = (await readLineWithCompletion(rl, `${c.green}You:${c.reset} `)).trim();
+      const text = (await readLineWithCompletion(rl, `${c.green}You:${c.reset} `, history)).trim();
       if (!text) continue;
+
+      history.push(text);
 
       const slashResult = await dispatchSlashCommand(text, ctx);
       if (slashResult === 'break') break;


### PR DESCRIPTION
Introduce InputHistory class to track all non-empty inputs entered during a CLI session (including slash commands). Consecutive identical entries are de-duped. Up arrow navigates backwards through history (newest first); Down arrow navigates forward. Any in-progress draft typed before browsing is saved and restored when navigating back to the live position. History is in-session only and cleared on exit.

- input-history.ts: new InputHistory class with push, navigateBack, navigateForward, reset, and isNavigating
- input-history.test.ts: full unit test coverage (18 cases)
- readline-completion.ts: accept optional InputHistory; delegate Up/Down to history when autocomplete menu is closed; reset on Enter
- run.ts: create InputHistory instance, pass to readLineWithCompletion, push each non-empty input before dispatch

## Summary

<!-- What does this PR do? One or two sentences. -->

## Changes

<!-- List the notable changes per package. Remove sections that do not apply. -->

<!--
### `packages/core`

- 

### `packages/cli`

- 

### `packages/desktop`

- 
-->

## Testing

- [x] Unit tests added / updated
- [x] All existing tests pass (`pnpm test`)
- [x] Manually tested in CLI
- [x] Manually tested in Desktop app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive CLI input history with up/down navigation, consecutive-entry de-duplication, draft preservation while browsing, forward/back restore behavior, session persistence during a prompt loop, and auto-reset on submit.
* **Tests**
  * Comprehensive tests for push, back/forward navigation, dedupe, draft save/restore, navigation state, and reset.
* **Documentation**
  * Added repository-wide agent/contributor guidelines and updated commit message guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->