### PR TITLE
feat(obsidian): add Obsidian plugin with chat sidebar

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,9 +30,9 @@ reviews:
         and correct teardown of event listeners and commands.
     - path: "packages/**/*.test.ts"
       instructions: >
-        Verify tests follow the red-green-refactor TDD workflow. Flag tests
-        that only cover the happy path, missing edge cases, or boundary
-        conditions. Ensure each test has a clear arrange-act-assert structure.
+        Flag tests that only cover the happy path, miss edge cases or
+        boundary conditions, use non-deterministic assertions, or lack a
+        clear arrange-act-assert structure.
 
 tone_instructions: >
   Provide architectural insights on system design, scalability, and

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,41 @@
+reviews:
+  profile: assertive
+  sequence_diagrams: true
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  related_issues: true
+  related_prs: true
+  assess_linked_issues: true
+  estimate_code_review_effort: true
+  review_details: true
+  path_instructions:
+    - path: "packages/core/src/**/*.ts"
+      instructions: >
+        Focus on architectural patterns, dependency management, and system
+        design impact. This is shared domain logic - flag anything that
+        couples core to a specific consumer (cli, desktop, obsidian-plugin).
+    - path: "packages/cli/src/**/*.ts"
+      instructions: >
+        Focus on separation of concerns between orchestration, rendering, and
+        domain logic. CLI should delegate to core; flag any domain logic that
+        belongs in @curraint/core instead.
+    - path: "packages/desktop/src/**/*.ts"
+      instructions: >
+        Focus on Electron main/renderer process boundaries, IPC safety, and
+        BrowserWindow lifecycle management. Flag direct DOM access from main
+        or any use of remote module.
+    - path: "packages/obsidian-plugin/src/**/*.ts"
+      instructions: >
+        Focus on Obsidian API usage, plugin lifecycle (onload/onunload),
+        and correct teardown of event listeners and commands.
+    - path: "packages/**/*.test.ts"
+      instructions: >
+        Verify tests follow the red-green-refactor TDD workflow. Flag tests
+        that only cover the happy path, missing edge cases, or boundary
+        conditions. Ensure each test has a clear arrange-act-assert structure.
+
+tone_instructions: >
+  Provide architectural insights on system design, scalability, and
+  long-term maintainability. Flag violations of the monorepo's core
+  principle: domain logic in @curraint/core, consumer-specific code in
+  the respective package.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Report broken behavior, regressions, or incorrect results.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please search existing issues before opening a new one. Include a small reproduction when possible.
+  - type: checkboxes
+    id: affected-areas
+    attributes:
+      label: Affected areas
+      description: Select every package or surface where you can reproduce the problem.
+      options:
+        - label: Core
+        - label: CLI
+        - label: Desktop app
+        - label: Desktop E2E coverage
+        - label: Obsidian plugin
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the broken behavior or regression.
+      placeholder: A short description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reliable reproduction you have.
+      placeholder: |
+        1. Open ...
+        2. Run ...
+        3. Click ...
+        4. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions and platform details.
+      placeholder: |
+        OS:
+        Node.js:
+        pnpm:
+        App/package version or commit:
+    validations:
+      required: true
+  - type: input
+    id: provider-model
+    attributes:
+      label: Provider and model
+      description: For chat, streaming, or response issues, note the provider and model.
+      placeholder: openai / gpt-4o-mini
+  - type: dropdown
+    id: streaming
+    attributes:
+      label: Was streaming active?
+      options:
+        - Not applicable
+        - Yes
+        - No
+    validations:
+      required: true
+  - type: dropdown
+    id: reasoning-tags
+    attributes:
+      label: Did the response include <think> or <reasoning> tags?
+      options:
+        - Not applicable
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs, stack traces, or screenshots. Redact secrets first.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for existing issues.
+          required: true
+        - label: I removed secrets, tokens, and private data from logs and screenshots.
+          required: true
+        - label: I can still reproduce this issue on the current main branch or latest build.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/curraint/curraint/blob/main/CONTRIBUTING.md
+    about: Review local setup, testing expectations, and pull request guidance.
+  - name: Security reporting guidance
+    url: https://github.com/curraint/curraint/blob/main/CONTRIBUTING.md#security
+    about: Do not open public issues for vulnerabilities or sensitive disclosures.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: Feature request
+description: Propose a user-facing improvement, workflow change, or new capability.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+
+        High-signal requests explain the problem first, then the proposed solution.
+  - type: checkboxes
+    id: affected-areas
+    attributes:
+      label: Target areas
+      description: Select every package or surface this request would affect.
+      options:
+        - label: Core
+        - label: CLI
+        - label: Desktop app
+        - label: Desktop E2E coverage
+        - label: Obsidian plugin
+        - label: Docs, CI, or tooling
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What is missing, difficult, or frustrating today?
+      placeholder: Describe the user problem or workflow gap.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the behavior, UX, or API you want.
+      placeholder: Describe the change you want to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative ideas you evaluated.
+      placeholder: Optional, but helpful for trade-off discussion.
+  - type: textarea
+    id: impact
+    attributes:
+      label: User impact
+      description: Who benefits, and how often does this come up?
+      placeholder: Explain the practical value of this change.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: If this shipped, what would "done" look like?
+      placeholder: |
+        - Users can ...
+        - Settings allow ...
+        - Docs cover ...
+    validations:
+      required: true
+  - type: textarea
+    id: mockups
+    attributes:
+      label: Mockups, screenshots, or examples
+      description: Add references to existing tools, screenshots, or UI sketches if helpful.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for existing requests.
+          required: true
+        - label: This request describes a user problem, not only an implementation detail.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,72 @@
 ## Summary
 
-<!-- What does this PR do? One or two sentences. -->
+<!-- What changed? Keep this to one or two sentences. -->
+
+## Why
+
+<!-- What problem does this solve, or why is this change worth making? -->
+
+## Related Issue
+
+<!-- Link the issue, discussion, or follow-up task when one exists. Example: Closes #123 -->
+
+## Scope
+
+<!-- Check every package or area touched by this PR. -->
+
+- [ ] `packages/core`
+- [ ] `packages/cli`
+- [ ] `packages/desktop`
+- [ ] `packages/desktop-e2e`
+- [ ] `packages/obsidian-plugin`
+- [ ] Docs, CI, or tooling only
 
 ## Changes
 
-<!-- List the notable changes per package. Remove sections that do not apply. -->
-
-<!--
-### `packages/core`
+<!-- List the most important behavior, API, or UX changes. -->
 
 - 
-
-### `packages/cli`
-
-- 
-
-### `packages/desktop`
-
-- 
--->
 
 ## Testing
 
-- [ ] Unit tests added / updated
-- [ ] All existing tests pass (`pnpm test`)
-- [ ] Manually tested in CLI
-- [ ] Manually tested in Desktop app
+<!-- List the exact commands you ran and any manual coverage. If something was not tested, say why. -->
+
+### Automated
+
+- [ ] `pnpm build`
+- [ ] `pnpm test`
+- [ ] Package-specific build or test commands noted below
+
+### Manual
+
+- [ ] CLI
+- [ ] Desktop app
+- [ ] Obsidian plugin
+- [ ] Not applicable
+
+### Commands run
+
+```text
+# Example:
+# pnpm --filter @curraint/core test
+```
+
+## Screenshots or Recordings
+
+<!-- Required for visible UI changes when practical. -->
+
+## Risks and Follow-ups
+
+<!-- Call out rollout risk, known gaps, or follow-up work. Use "None" if there is nothing notable. -->
+
+- Risk:
+- Follow-up:
+
+## Checklist
+
+- [ ] PR is scoped to a single concern
+- [ ] Tests were added or updated for behavior changes
+- [ ] Docs were updated for user-facing changes
+- [ ] New settings include defaults, normalization, and UI wiring where applicable
+- [ ] Breaking changes are documented in the PR description
+- [ ] I checked for accidental secrets or sensitive data before opening this PR

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ Format: `<type>(<optional scope>): <short imperative description>`
 | `chore` | Tooling, deps, CI, config |
 | `perf` | Performance improvement |
 
-**Scopes** (optional): `core`, `cli`, `desktop`, `ci`
+**Scopes** (optional): `core`, `cli`, `desktop`, `obsidian`, `ci`
 
 > **Important:** When the change is only to documentation or markdown files (`.md`, `README`, `CONTRIBUTING`, etc.), always use `docs` as the **type** — never as a scope on another type. For example, use `docs: update README` or `docs(ci): clarify workflow triggers`, never `feat(docs): ...`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 out
 *.log
 .DS_Store
+packages/obsidian-plugin/.vault-path

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,6 +71,31 @@
       "skipFiles": [
         "<node_internals>/**"
       ]
+    },
+    {
+      "name": "curraint: Obsidian Plugin (Build)",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/obsidian-plugin",
+      "program": "${workspaceFolder}/packages/obsidian-plugin/esbuild.config.mjs",
+      "preLaunchTask": "pnpm: build:core",
+      "console": "integratedTerminal",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    },
+    {
+      "name": "curraint: Obsidian Plugin (Watch)",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/obsidian-plugin",
+      "program": "${workspaceFolder}/packages/obsidian-plugin/esbuild.config.mjs",
+      "args": ["--watch"],
+      "preLaunchTask": "pnpm: build:core",
+      "console": "integratedTerminal",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,6 +34,34 @@
       "dependsOn": ["pnpm: build:core"],
       "group": "build",
       "problemMatcher": []
+    },
+    {
+      "label": "pnpm: build:obsidian-plugin",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["--filter", "@curraint/obsidian-plugin", "build"],
+      "dependsOn": ["pnpm: build:core"],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "pnpm: dev:obsidian-plugin",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["--filter", "@curraint/obsidian-plugin", "dev"],
+      "dependsOn": ["pnpm: build:core"],
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "pnpm: deploy:obsidian-plugin",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["--filter", "@curraint/obsidian-plugin", "run", "deploy"],
+      "dependsOn": ["pnpm: build:obsidian-plugin"],
+      "group": "build",
+      "problemMatcher": []
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Format: `<type>(<optional scope>): <short imperative description>`
 | `chore` | Tooling, deps, CI, config |
 | `perf` | Performance improvement |
 
-**Scopes** (optional): `core`, `cli`, `desktop`, `ci`
+**Scopes** (optional): `core`, `cli`, `desktop`, `obsidian`, `ci`
 
 > **Important:** When the change is only to documentation or markdown files (`.md`, `README`, `CONTRIBUTING`, etc.), always use `docs` as the **type** — never as a scope on another type. For example, use `docs: update README` or `docs(ci): clarify workflow triggers`, never `feat(docs): ...`.
 
@@ -79,6 +79,7 @@ This is a pnpm monorepo. All packages live under `packages/`.
 | `packages/cli` (`@curraint/cli`) | Terminal interface — depends on `@curraint/core` |
 | `packages/desktop` (`@curraint/desktop`) | Electron desktop app (main process + React renderer) — depends on `@curraint/core` |
 | `packages/desktop-e2e` (`@curraint/desktop-e2e`) | Playwright end-to-end tests for the desktop app |
+| `packages/obsidian-plugin` (`@curraint/obsidian-plugin`) | Obsidian plugin - adds a chat sidebar to any vault — depends on `@curraint/core` |
 
 ## Architecture principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Run a specific package in isolation:
 pnpm --filter @curraint/core build
 pnpm --filter @curraint/desktop build
 pnpm --filter @curraint/cli build
+pnpm --filter @curraint/obsidian-plugin build
 ```
 
 Start the desktop app or CLI locally:
@@ -96,7 +97,7 @@ This is a **pnpm monorepo**. All packages live under `packages/`.
 | `chore` | Tooling, deps, CI, config |
 | `perf` | Performance improvement |
 
-**Scopes** (optional) help narrow the change: `(core)`, `(cli)`, `(desktop)`, `(ci)`.
+**Scopes** (optional) help narrow the change: `(core)`, `(cli)`, `(desktop)`, `(obsidian)`, `(ci)`.
 
 **Examples:**
 
@@ -149,6 +150,32 @@ Breaking changes must include `BREAKING CHANGE:` in the commit body or footer.
 - Session I/O, markdown rendering, and settings UI are separate modules.
 - Avoid blocking the event loop; prefer streaming and async patterns throughout.
 
+### Obsidian plugin
+
+- The plugin is built with esbuild to a single `dist/main.js` bundle; `manifest.json` and `styles.css` are copied to `dist/` alongside it.
+- Use `pnpm --filter @curraint/obsidian-plugin dev` for watch mode during development.
+- To test locally, use the deploy task (see below) or copy `dist/` contents manually to `.obsidian/plugins/curraint/` inside a vault, then enable the plugin and use `Ctrl+Shift+I` to open the DevTools console.
+- The plugin owns its own encrypted API key in `data.json` (separate from the desktop/CLI secrets).
+- Do not add Obsidian-specific logic to `packages/core`; only promote logic there when it is genuinely shared across all consumers.
+
+#### One-click deploy to a local vault
+
+A deploy script copies the built plugin files directly into your local Obsidian vault for fast iteration:
+
+```bash
+pnpm --filter @curraint/obsidian-plugin run deploy
+```
+
+**One-time setup:** create `packages/obsidian-plugin/.vault-path` (this file is gitignored) containing the absolute path to your vault root - nothing else, just the path on a single line:
+
+```
+C:\Users\you\Documents\MyVault
+```
+
+Your vault root is the folder you open in Obsidian - the one that contains your notes and an `.obsidian/` subfolder. The script writes to `<vault>/.obsidian/plugins/curraint/` and prints each copied file. It will error with a clear message if the file is missing or the path does not exist.
+
+The VS Code task **"pnpm: deploy:obsidian-plugin"** (Terminal > Run Task) runs the build and deploy in one step.
+
 ---
 
 ## Testing
@@ -167,6 +194,7 @@ Run tests for a single package:
 pnpm --filter @curraint/core test
 pnpm --filter @curraint/desktop test
 pnpm --filter @curraint/cli test
+pnpm --filter @curraint/obsidian-plugin test
 ```
 
 Run E2E tests (requires a built desktop app):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ This is a **pnpm monorepo**. All packages live under `packages/`.
 | `packages/core` | Shared business logic: chat sessions, providers, settings, secrets, context management |
 | `packages/cli` | Terminal interface — depends on `@curraint/core` |
 | `packages/desktop` | Electron desktop app (main process + React renderer) — depends on `@curraint/core` |
+| `packages/obsidian-plugin` | Obsidian plugin for vault-aware chat workflows — depends on `@curraint/core` |
 | `packages/desktop-e2e` | Playwright end-to-end tests for the desktop app |
 
 `@curraint/core` is the single source of truth for domain logic. Keep package-specific code in the relevant package; only promote logic to `core` when it is genuinely shared.

--- a/README.md
+++ b/README.md
@@ -7,35 +7,95 @@
 > APIs, configuration format, storage layout, and behaviour can change significantly
 > between releases without prior notice. Do not rely on it in production environments.
 
-curraint is a tray-first desktop and CLI AI chat client built with Electron + TypeScript.
+curraint is a tray-first desktop, CLI, and Obsidian AI chat client built with Electron + TypeScript.
 
-It supports OpenAI-compatible chat APIs (OpenAI, LM Studio, and custom endpoints) with streaming, reasoning-block controls, markdown rendering, and robust chat flow safeguards.
+It supports OpenAI-compatible chat APIs (OpenAI, LM Studio, and custom endpoints) with streaming, reasoning-block controls, markdown rendering, and robust chat flow safeguards, all powered by a shared `@curraint/core` library.
 
 ## Why curraint
 
-- Fast tray-first workflow for quick prompts
+- Fast tray-first workflow for quick prompts without switching apps
 - Cross-platform desktop support (Windows, macOS, Linux)
 - Optional local-model workflow through LM Studio
 - Provider-aware settings (OpenAI, LM Studio, Custom)
 - CLI mode for scripting and terminal-based usage
+- Obsidian plugin for in-vault AI chat with note context injection
 - Streaming-first UX with stop/cancel controls
-- Context safety with truncation + summary fallback
+- Context safety with automatic truncation and summary fallback
 
-## Features
+## Apps and packages
 
-- Always-on tray app with popover chat window
-- Settings window with provider selection and connection testing
-- Unread message indicator in tray icon + tooltip count
-- Enter to send, Shift+Enter for newline
-- OpenAI-compatible `/chat/completions` integration
-- Streaming responses with graceful non-stream fallback
-- Stop current response while preserving partial output
-- Edit user messages and regenerate from that point in history
-- Markdown rendering for assistant responses (tables, code, lists, headings)
-- Copy buttons for code blocks in responses
-- Configurable context safety limits (`max messages`, `max characters`)
-- Automatic history truncation with compact summary of removed context
-- Packaging support via `electron-builder`
+### 🖥️ Desktop (`@curraint/desktop`)
+
+The tray-first Electron app for quick, always-available AI chat.
+
+- Always-on tray app: left-click to open or close the chat popover
+- Right-click tray menu: `Open Chat`, `Settings`, `Quit`
+- **Quick Input**: a configurable global keyboard shortcut that opens a floating input bar from anywhere on the desktop
+- Unread message indicator with count in the tray icon tooltip
+- Settings window with provider selection, connection testing, and saved connections
+- Streaming responses with one-click stop that preserves partial output
+- Edit any user message and regenerate the conversation from that point
+- Markdown rendering: tables, code blocks with copy button, lists, and headings
+- Show or hide `<think>` / `<reasoning>` blocks from models that emit reasoning traces
+- Configurable context safety limits (max messages, max characters)
+- Automatic history truncation with a compact summary of removed context
+- Session saving: persist and resume named conversations across restarts (off by default)
+- Light and dark theme
+- Cross-platform packaging: Windows NSIS installer, macOS DMG, Linux AppImage and DEB
+
+### 💻 CLI (`@curraint/cli`)
+
+A terminal interface that shares the same chat engine as the desktop app.
+
+- Configure fully through environment variables, no config file required
+- Streaming, stop (`Ctrl+C`), and edit/regenerate flow identical to the desktop
+- Markdown rendering in the terminal via marked-terminal
+- Input history with up-arrow recall
+- Session saving with `/sessions-save on` and interactive session browser with `/sessions`
+- Slash commands:
+
+  | Command | Description |
+  |---|---|
+  | `/help` | Show available commands |
+  | `/history` | Print the current conversation history |
+  | `/sessions` | Browse and resume saved sessions interactively |
+  | `/sessions-save on\|off` | Enable or disable session saving |
+  | `/edit <number>` | Edit a previous user message and regenerate from that point |
+  | `/retry` | Regenerate the last assistant response |
+  | `/provider` | Change the active provider interactively |
+  | `/model` | Change the active model interactively |
+  | `/version` | Print the CLI version |
+  | `/clear` | Clear the screen and reset the current session |
+  | `/exit` | Exit the CLI |
+
+### 🔌 Obsidian plugin (`@curraint/obsidian-plugin`)
+
+A chat sidebar for any Obsidian vault, powered by `@curraint/core`.
+
+- Chat sidebar with full streaming, stop, and edit/regenerate support
+- Inject the active note as context with one click
+- Note picker: a multi-select, searchable modal to add any vault notes as context
+- Multiple simultaneous conversations with background streaming while switching between them
+- Editable conversation titles and a sessions modal to browse, rename, and delete saved conversations
+- Optional session saving (off by default) with configurable context limits (max messages, max characters)
+- Markdown/plain mode toggle per conversation
+- Encrypted API key storage (AES-256-GCM, machine-bound on desktop; Web Crypto AES-GCM on mobile)
+- Provider, model, and system prompt settings via the standard Obsidian settings tab
+
+> **Note:** The plugin stores its own encrypted API key separately from the desktop/CLI `secrets.json`. Keys are not shared between the plugin and the desktop/CLI apps.
+
+### 📦 Core (`@curraint/core`)
+
+The shared domain logic used by all apps and the plugin.
+
+- Streaming chat sessions: start, stop, and resume with a consistent API
+- Edit/regenerate flow: trim conversation history to any message and re-run from there
+- OpenAI-compatible provider abstraction supporting OpenAI, LM Studio, and Custom endpoints
+- Context safety: truncate history and generate a compact summary when limits are reached
+- AES-256-GCM encrypted secret storage with a per-machine key derived via PBKDF2-SHA256 (100,000 iterations)
+- Session persistence: save and restore named conversations
+- Settings management with normalisation and file-based persistence
+- Think-tag parsing: extract and show or hide `<think>` / `<reasoning>` blocks
 
 ## Tech stack
 
@@ -43,7 +103,7 @@ It supports OpenAI-compatible chat APIs (OpenAI, LM Studio, and custom endpoints
 - TypeScript
 - React + Vite
 - Tailwind/shadcn-style UI primitives
-- pnpm
+- pnpm monorepo
 - Vitest
 
 ## Requirements
@@ -65,7 +125,7 @@ Build:
 pnpm build
 ```
 
-Run desktop app:
+Run the desktop app:
 
 ```bash
 pnpm desktop
@@ -73,8 +133,8 @@ pnpm desktop
 
 ## Desktop usage
 
-- Left click tray icon: open/close chat popover
-- Right click tray icon: `Open Chat`, `Settings`, `Quit`
+- Left-click tray icon: open/close the chat popover
+- Right-click tray icon: `Open Chat`, `Settings`, `Quit`
 
 ### Settings
 
@@ -85,9 +145,9 @@ Configure:
 - API Base URL
 - Model
 - System Prompt
-- Reasoning block handling (`<think>` / `<reasoning>` show-hide)
-- Context safety limits in Advanced section
-- **Save sessions**, persist conversations so you can resume them later (off by default)
+- Reasoning block handling (`<think>` / `<reasoning>` show/hide)
+- Context safety limits in the Advanced section
+- **Save sessions**: persist conversations so you can resume them later (off by default)
 
 Use **Test Connection** to validate endpoint access before saving.
 
@@ -115,27 +175,12 @@ pnpm cli
 
 Behavior notes:
 
-- Uses the same shared chat-session core as desktop chat (streaming, stop, edit/regenerate flow).
-- Uses the same shared context-safety composition logic as desktop chat.
-- Works with OpenAI-compatible endpoints configured via environment variables.
-- Conversation history is **not saved by default**. To persist sessions across runs, use `/sessions-save on` (saved to `settings.json`). Once enabled, use `/sessions` to browse and resume past conversations.
-- CLI commands:
-	- `/help`, show available commands
-	- `/history`, print conversation history
-	- `/sessions`, browse and resume saved sessions
-	- `/sessions-save on|off`, enable or disable session saving
-	- `/edit <number>`, edit a previous user message and regenerate from that point
-	- `Ctrl+C` while streaming, stop current response
+- Uses the same shared chat-session core as the desktop (streaming, stop, edit/regenerate flow).
+- Works with any OpenAI-compatible endpoint configured via environment variables.
+- Conversation history is **not saved by default**. Use `/sessions-save on` to enable persistence; sessions are saved to `settings.json`. Use `/sessions` to browse and resume past conversations once saving is on.
+- Use `Ctrl+C` while streaming to stop the current response.
 
 ## Obsidian plugin
-
-The `packages/obsidian-plugin` package provides an Obsidian plugin that adds a chat sidebar to any Obsidian vault. It uses the same `@curraint/core` chat engine as the desktop and CLI.
-
-**Features:**
-- Chat sidebar powered by `@curraint/core` (streaming, stop, edit/regenerate)
-- Optional "include current note" toggle to inject the active note as context
-- Encrypted API key storage in `data.json` (AES-256-GCM, machine-bound)
-- Provider/model/system-prompt settings via the standard Obsidian settings tab
 
 **Build:**
 
@@ -144,8 +189,6 @@ pnpm --filter @curraint/obsidian-plugin build
 ```
 
 Output is written to `packages/obsidian-plugin/dist/` (`main.js`, `manifest.json`, `styles.css`). Copy the contents of `dist/` to `.obsidian/plugins/curraint/` inside your vault, then enable the plugin in Obsidian settings.
-
-**Note:** The plugin stores its own encrypted API key separately from the desktop/CLI `secrets.json`. Keys are not shared between the plugin and the desktop/CLI apps.
 
 ## Security
 
@@ -241,7 +284,7 @@ Then open the app normally. This is safe, the flag is added automatically by mac
 ## CI/CD pipelines
 
 - `CI` ([.github/workflows/ci.yml](.github/workflows/ci.yml))
-	- Manual trigger only (`workflow_dispatch`)
+	- Push or PR to `main`, and manual (`workflow_dispatch`)
 	- Runs `pnpm build` and `pnpm test`
 
 - `Package and Release` ([.github/workflows/package-release.yml](.github/workflows/package-release.yml))

--- a/README.md
+++ b/README.md
@@ -1,234 +1,281 @@
 # curraint
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+![Node 22+](https://img.shields.io/badge/Node-22%2B-43853d)
+![pnpm 10+](https://img.shields.io/badge/pnpm-10%2B-f69220)
+![Status Alpha](https://img.shields.io/badge/status-alpha-c98a00)
 
 > [!CAUTION]
 > **Early alpha: expect breaking changes.** curraint is under active development.
-> APIs, configuration format, storage layout, and behaviour can change significantly
+> APIs, configuration format, storage layout, and behavior can change significantly
 > between releases without prior notice. Do not rely on it in production environments.
 
-curraint is a tray-first desktop, CLI, and Obsidian AI chat client built with Electron + TypeScript.
+> [!TIP]
+> **One core. Three interfaces.** curraint keeps the same chat flow across a tray-first desktop app, a terminal CLI, and an Obsidian sidebar.
 
-It supports OpenAI-compatible chat APIs (OpenAI, LM Studio, and custom endpoints) with streaming, reasoning-block controls, markdown rendering, and robust chat flow safeguards, all powered by a shared `@curraint/core` library.
+curraint is an AI chat client built around a shared TypeScript core. Use the desktop app when you want a fast tray workflow, the CLI when you want scripting and terminal control, and the Obsidian plugin when your work already lives in notes. All three surfaces share the same chat engine, so streaming, edit and regenerate, context safety, provider behavior, and session handling stay consistent.
+
+[Why curraint](#why-curraint) · [Choose your interface](#choose-your-interface) · [Quick start](#quick-start) · [How it works](#how-curraint-works) · [Security](#security-and-storage) · [Development](#development)
 
 ## Why curraint
 
-- Fast tray-first workflow for quick prompts without switching apps
-- Cross-platform desktop support (Windows, macOS, Linux)
-- Optional local-model workflow through LM Studio
-- Provider-aware settings (OpenAI, LM Studio, Custom)
-- CLI mode for scripting and terminal-based usage
-- Obsidian plugin for in-vault AI chat with note context injection
-- Streaming-first UX with stop/cancel controls
-- Context safety with automatic truncation and summary fallback
+Most AI chat tools make you choose one surface and live with its tradeoffs. curraint is built around a different idea: the interface can change, but the chat behavior should not.
 
-## Apps and packages
+- **Tray-first when speed matters.** Open chat without hunting for a window.
+- **Terminal-first when automation matters.** Keep prompts and results in the same place as the rest of your workflow.
+- **Vault-aware when notes matter.** Pull active or selected Obsidian notes directly into the conversation.
+- **Same conversation controls everywhere.** Stream responses, stop mid-generation, edit earlier messages, and regenerate from that point.
+- **Hosted or local models.** Use OpenAI, LM Studio, or any OpenAI-compatible endpoint.
+- **Context safety built in.** Long chats are truncated safely with a summary fallback instead of failing abruptly.
 
-### 🖥️ Desktop (`@curraint/desktop`)
+## Choose your interface
 
-The tray-first Electron app for quick, always-available AI chat.
+| Interface | Best for | Highlights | Package |
+|---|---|---|---|
+| Desktop | Fast day-to-day chat from anywhere on your machine | Tray popover, global quick input, settings UI, unread indicator, packaged app builds | `@curraint/desktop` |
+| CLI | Terminal sessions, scripting, and keyboard-driven workflows | Streaming terminal output, slash commands, edit and retry flow, environment-based config | `@curraint/cli` |
+| Obsidian | Conversations tied to notes and vault context | Sidebar chat, active note injection, note picker, concurrent conversations, Obsidian-native settings | `@curraint/obsidian-plugin` |
+| Core | Shared chat behavior across every surface | Providers, sessions, settings, encryption, context truncation, think-tag parsing | `@curraint/core` |
 
-- Always-on tray app: left-click to open or close the chat popover
-- Right-click tray menu: `Open Chat`, `Settings`, `Quit`
-- **Quick Input**: a configurable global keyboard shortcut that opens a floating input bar from anywhere on the desktop
-- Unread message indicator with count in the tray icon tooltip
-- Settings window with provider selection, connection testing, and saved connections
-- Streaming responses with one-click stop that preserves partial output
-- Edit any user message and regenerate the conversation from that point
-- Markdown rendering: tables, code blocks with copy button, lists, and headings
-- Show or hide `<think>` / `<reasoning>` blocks from models that emit reasoning traces
-- Configurable context safety limits (max messages, max characters)
-- Automatic history truncation with a compact summary of removed context
-- Session saving: persist and resume named conversations across restarts (off by default)
-- Light and dark theme
-- Cross-platform packaging: Windows NSIS installer, macOS DMG, Linux AppImage and DEB
+## Architecture
 
-### 💻 CLI (`@curraint/cli`)
+Yes. GitHub renders Mermaid in README files, and this is a good fit for curraint because the structure is simple and important.
 
-A terminal interface that shares the same chat engine as the desktop app.
+```mermaid
+flowchart TD
+    Desktop["Desktop app<br/>@curraint/desktop"]
+    CLI["CLI<br/>@curraint/cli"]
+    Obsidian["Obsidian plugin<br/>@curraint/obsidian-plugin"]
 
-- Configure fully through environment variables, no config file required
-- Streaming, stop (`Ctrl+C`), and edit/regenerate flow identical to the desktop
-- Markdown rendering in the terminal via marked-terminal
-- Input history with up-arrow recall
-- Session saving with `/sessions-save on` and interactive session browser with `/sessions`
-- Slash commands:
+    Core["@curraint/core<br/>shared chat engine"]
 
-  | Command | Description |
-  |---|---|
-  | `/help` | Show available commands |
-  | `/history` | Print the current conversation history |
-  | `/sessions` | Browse and resume saved sessions interactively |
-  | `/sessions-save on\|off` | Enable or disable session saving |
-  | `/edit <number>` | Edit a previous user message and regenerate from that point |
-  | `/retry` | Regenerate the last assistant response |
-  | `/provider` | Change the active provider interactively |
-  | `/model` | Change the active model interactively |
-  | `/version` | Print the CLI version |
-  | `/clear` | Clear the screen and reset the current session |
-  | `/exit` | Exit the CLI |
+    Desktop --> Core
+    CLI --> Core
+    Obsidian --> Core
 
-### 🔌 Obsidian plugin (`@curraint/obsidian-plugin`)
+    Core --> Providers["Providers<br/>OpenAI, LM Studio, Custom"]
+    Core --> Sessions["Sessions and settings"]
+    Core --> Context["Context truncation and summaries"]
+```
 
-A chat sidebar for any Obsidian vault, powered by `@curraint/core`.
+## Shared behavior across interfaces
 
-- Chat sidebar with full streaming, stop, and edit/regenerate support
-- Inject the active note as context with one click
-- Note picker: a multi-select, searchable modal to add any vault notes as context
-- Multiple simultaneous conversations with background streaming while switching between them
-- Editable conversation titles and a sessions modal to browse, rename, and delete saved conversations
-- Optional session saving (off by default) with configurable context limits (max messages, max characters)
-- Markdown/plain mode toggle per conversation
-- Encrypted API key storage (AES-256-GCM, machine-bound on desktop; Web Crypto AES-GCM on mobile)
-- Provider, model, and system prompt settings via the standard Obsidian settings tab
-
-> **Note:** The plugin stores its own encrypted API key separately from the desktop/CLI `secrets.json`. Keys are not shared between the plugin and the desktop/CLI apps.
-
-### 📦 Core (`@curraint/core`)
-
-The shared domain logic used by all apps and the plugin.
-
-- Streaming chat sessions: start, stop, and resume with a consistent API
-- Edit/regenerate flow: trim conversation history to any message and re-run from there
-- OpenAI-compatible provider abstraction supporting OpenAI, LM Studio, and Custom endpoints
-- Context safety: truncate history and generate a compact summary when limits are reached
-- AES-256-GCM encrypted secret storage with a per-machine key derived via PBKDF2-SHA256 (100,000 iterations)
-- Session persistence: save and restore named conversations
-- Settings management with normalisation and file-based persistence
-- Think-tag parsing: extract and show or hide `<think>` / `<reasoning>` blocks
-
-## Tech stack
-
-- Electron
-- TypeScript
-- React + Vite
-- Tailwind/shadcn-style UI primitives
-- pnpm monorepo
-- Vitest
-
-## Requirements
-
-- Node.js 22+
-- pnpm 10+
+| Capability | Desktop | CLI | Obsidian |
+|---|---|---|---|
+| Streaming responses | Yes | Yes | Yes |
+| Stop and keep partial output | Yes | Yes | Yes |
+| Edit a previous user message and regenerate | Yes | Yes | Yes |
+| Optional session saving | Yes | Yes | Yes |
+| Context truncation with summary fallback | Yes | Yes | Yes |
+| OpenAI-compatible providers | Yes | Yes | Yes |
+| Markdown rendering | Yes | Yes | Yes |
+| LM Studio local models | Yes | Yes | Yes |
+| Note context injection | No | No | Yes |
 
 ## Quick start
 
-Install:
+### Requirements
+
+- Node.js 22+
+- pnpm 10+
+- Obsidian, if you want to use the plugin
+
+### Install dependencies
 
 ```bash
 pnpm install
 ```
 
-Build:
+### Build everything
 
 ```bash
 pnpm build
 ```
 
-Run the desktop app:
+### Run the desktop app
 
 ```bash
 pnpm desktop
 ```
 
-## Desktop usage
+Desktop highlights:
 
-- Left-click tray icon: open/close the chat popover
-- Right-click tray icon: `Open Chat`, `Settings`, `Quit`
+- Left-click the tray icon to open or close the chat popover.
+- Right-click the tray icon for `Open Chat`, `Settings`, and `Quit`.
+- Use the optional global quick input shortcut to open a floating input bar from anywhere.
 
-### Settings
+### Run the CLI
 
-Configure:
+Set environment variables:
 
-- Provider (`OpenAI`, `LM Studio`, `Custom OpenAI-compatible`)
-- API Key
-- API Base URL
-- Model
-- System Prompt
-- Reasoning block handling (`<think>` / `<reasoning>` show/hide)
-- Context safety limits in the Advanced section
-- **Save sessions**: persist conversations so you can resume them later (off by default)
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `CURRAINT_PROVIDER` | No | `openai` | `openai`, `lmstudio`, or `custom` |
+| `CURRAINT_API_KEY` | OpenAI only | None | Optional for LM Studio and custom endpoints |
+| `CURRAINT_BASE_URL` | No | `https://api.openai.com/v1` | Point to LM Studio or any OpenAI-compatible API |
+| `CURRAINT_MODEL` | No | `gpt-4o-mini` | Any model your endpoint supports |
+| `CURRAINT_SYSTEM_PROMPT` | No | None | Optional system prompt |
 
-Use **Test Connection** to validate endpoint access before saving.
-
-### LM Studio quick setup
-
-- Provider: `LM Studio (Local)`
-- Default base URL: `http://127.0.0.1:1234`
-- API key: optional
-
-## CLI usage
-
-Environment variables:
-
-- `CURRAINT_PROVIDER` (optional: `openai`, `lmstudio`, `custom`; default `openai`)
-- `CURRAINT_API_KEY` (required for `openai`, optional for `lmstudio` and `custom`)
-- `CURRAINT_BASE_URL` (optional, default `https://api.openai.com/v1`)
-- `CURRAINT_MODEL` (optional, default `gpt-4o-mini`)
-- `CURRAINT_SYSTEM_PROMPT` (optional)
-
-Run:
+Run the CLI:
 
 ```bash
 pnpm cli
 ```
 
-Behavior notes:
+CLI behavior:
 
-- Uses the same shared chat-session core as the desktop (streaming, stop, edit/regenerate flow).
-- Works with any OpenAI-compatible endpoint configured via environment variables.
-- Conversation history is **not saved by default**. Use `/sessions-save on` to enable persistence; sessions are stored by the SessionsManager as dedicated JSON files in the app user-data `sessions/` directory, using `<session-id>.json` filenames, while `settings.json` remains config-only. Use `/sessions` to browse and resume saved conversations.
-- Use `Ctrl+C` while streaming to stop the current response.
+- Streaming, stop, edit, and regenerate use the same core behavior as desktop.
+- Conversation history is not saved by default.
+- Use `/sessions-save on` to persist sessions and `/sessions` to browse and resume them.
+- Press `Ctrl+C` while streaming to stop the current response.
 
-## Obsidian plugin
+<details>
+<summary><strong>CLI commands</strong></summary>
 
-**Build:**
+| Command | Description |
+|---|---|
+| `/help` | Show available commands |
+| `/history` | Print the current conversation history |
+| `/sessions` | Browse and resume saved sessions interactively |
+| `/sessions-save on\|off` | Enable or disable session saving |
+| `/edit <number>` | Edit a previous user message and regenerate from that point |
+| `/retry` | Regenerate the last assistant response |
+| `/provider` | Change the active provider interactively |
+| `/model` | Change the active model interactively |
+| `/version` | Print the CLI version |
+| `/clear` | Clear the screen and reset the current session |
+| `/exit` | Exit the CLI |
+
+</details>
+
+### Build the Obsidian plugin
 
 ```bash
 pnpm --filter @curraint/obsidian-plugin build
 ```
 
-Output is written to `packages/obsidian-plugin/dist/` (`main.js`, `manifest.json`, `styles.css`). Copy the contents of `dist/` to `.obsidian/plugins/curraint/` inside your vault, then enable the plugin in Obsidian settings.
+The build output is written to `packages/obsidian-plugin/dist/`.
 
-## Security
+To install it in a vault:
+
+1. Copy `main.js`, `manifest.json`, and `styles.css` from `packages/obsidian-plugin/dist/` into `.obsidian/plugins/curraint/` in your vault.
+2. Open Obsidian settings.
+3. Enable the plugin.
+
+Plugin highlights:
+
+- Chat sidebar with streaming, stop, and edit or regenerate support.
+- Add the active note as context with one click.
+- Search and select any vault notes as additional context.
+- Keep multiple conversations open and continue streaming in the background while switching between them.
+
+### LM Studio local setup
+
+Use these settings in desktop, CLI, or Obsidian:
+
+- Provider: `LM Studio (Local)` or `lmstudio`
+- Base URL: `http://127.0.0.1:1234`
+- API key: optional
+
+## How curraint works
+
+1. **Choose a provider.** curraint connects to OpenAI, LM Studio, or any OpenAI-compatible endpoint.
+2. **Start streaming immediately.** Responses arrive incrementally, and you can stop generation without losing the partial result.
+3. **Fix the conversation in place.** Edit any earlier user message and regenerate the thread from that point instead of starting over.
+4. **Protect long-running chats.** When conversations get too large, curraint trims older history and inserts a compact summary.
+5. **Save sessions only when you want to.** Session persistence is optional and remains off by default.
+
+## Desktop details
+
+The desktop app is designed for fast, low-friction chat from the system tray.
+
+- Always-on tray app with unread count in the tooltip
+- Settings window with provider selection, connection testing, and saved connections
+- Markdown rendering with tables, headings, lists, code blocks, and copy buttons
+- Show or hide `<think>` and `<reasoning>` blocks from models that emit reasoning traces
+- Configurable context limits for max messages and max characters
+- Light and dark theme
+- Cross-platform packaging for Windows, macOS, and Linux
+
+## Obsidian details
+
+The plugin is designed for conversations that should stay close to your notes.
+
+- Sidebar chat that uses the shared core behavior instead of a separate implementation
+- Note picker for multi-select context injection from anywhere in the vault
+- Editable conversation titles and a sessions modal to browse, rename, and delete saved sessions
+- Markdown or plain text mode per conversation
+- Optional session saving with configurable context limits
+
+> **Note:** The plugin stores its own encrypted API key separately from the desktop and CLI `secrets.json`. Keys are not shared between the plugin and the desktop or CLI apps.
+
+## Security and storage
 
 ### API key storage
 
-API keys are **never written to `settings.json`** in plain text.  They are stored in a separate encrypted file:
+API keys are never written to `settings.json` in plain text. Desktop and CLI secrets are stored in a separate encrypted file:
 
 | Platform | Path |
-|----------|------|
-| Windows  | `%APPDATA%\curraint\secrets.json` |
-| macOS    | `~/Library/Application Support/curraint/secrets.json` |
-| Linux    | `~/.config/curraint/secrets.json` |
+|---|---|
+| Windows | `%APPDATA%\curraint\secrets.json` |
+| macOS | `~/Library/Application Support/curraint/secrets.json` |
+| Linux | `~/.config/curraint/secrets.json` |
 
-Each value is individually encrypted with **AES-256-GCM**.  The encryption key is derived from the current machine's hostname and OS username using PBKDF2-SHA256 (100 000 iterations), making the secrets file unreadable on any other machine or user account without access to the same credentials.
+Each value is encrypted with AES-256-GCM. The encryption key is derived from the current machine hostname and OS username using PBKDF2-SHA256 with 600,000 iterations.
 
-On Unix systems the file is created with `0600` permissions (owner read/write only).
+Additional details:
 
-The Desktop and CLI share the same `secrets.json`, so API keys entered in either app are immediately available in the other, no re-entry needed.
+- On Unix systems, the file is created with `0600` permissions.
+- Desktop and CLI share the same `secrets.json`.
+- The `CURRAINT_API_KEY` environment variable always takes precedence over the stored secret.
+- The desktop, CLI, and Obsidian desktop code paths now use PBKDF2-SHA256 with 600,000 iterations.
+- The Obsidian plugin uses separate encrypted storage on mobile via Web Crypto AES-GCM.
 
-The `CURRAINT_API_KEY` environment variable always takes precedence over the stored secret when set.
+### settings.json
 
-### `settings.json`
+Non-sensitive settings such as provider, base URL, model, system prompt, theme, and shortcuts remain in plain JSON in `settings.json`.
 
-Non-sensitive settings (provider, base URL, model, system prompt, theme, shortcuts) continue to be stored in plain JSON in `settings.json` alongside `secrets.json`.
+## Development
 
-## Testing
+### Monorepo layout
 
-Run unit tests:
+This repository is a pnpm monorepo with packages under `packages/`.
+
+| Package | Description |
+|---|---|
+| `packages/core` | Shared domain logic for chat sessions, providers, settings, secrets, context management, and session persistence |
+| `packages/desktop` | Electron desktop app |
+| `packages/cli` | Terminal interface |
+| `packages/obsidian-plugin` | Obsidian plugin |
+| `packages/desktop-e2e` | Playwright end-to-end tests for the desktop app |
+
+### Common commands
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Build all packages:
+
+```bash
+pnpm build
+```
+
+Run all tests:
 
 ```bash
 pnpm test
 ```
 
-Watch mode:
+Run desktop end-to-end tests:
 
 ```bash
-pnpm test:watch
+pnpm test:e2e
 ```
 
-Build specific packages:
+Run package-specific builds:
 
 ```bash
 pnpm --filter @curraint/core build
@@ -237,77 +284,61 @@ pnpm --filter @curraint/cli build
 pnpm --filter @curraint/obsidian-plugin build
 ```
 
-## Packaging and releases
+### Packaging desktop releases
 
-Create packages with current host defaults:
+Create desktop packages with host defaults:
 
 ```bash
 pnpm --filter @curraint/desktop package
 ```
 
-Targets configured:
+Targets:
 
+- Windows: NSIS installer
 - macOS: DMG
-- Windows: NSIS (`.exe`)
-- Linux: AppImage + DEB
+- Linux: AppImage and DEB
 
 Platform-specific examples:
 
 ```bash
-# Windows installer (.exe via NSIS)
+# Windows
 pnpm --filter @curraint/desktop package -- --win
 
-# macOS disk image (.dmg)
+# macOS
 pnpm --filter @curraint/desktop package -- --mac
 
-# Linux artifacts (.AppImage / .deb)
+# Linux
 pnpm --filter @curraint/desktop package -- --linux
 ```
 
-Notes:
+#### macOS quarantine warning
 
-- Build `.exe` on Windows for best compatibility.
-- Build `.dmg` on macOS for best compatibility and signing/notarization workflows.
+Because the DMG is not code-signed or notarized, macOS Gatekeeper may show an "app is damaged" warning after installation.
 
-### macOS, "app is damaged" warning
-
-Because the DMG is not code-signed or notarized (no Apple Developer account), macOS Gatekeeper may block the app with a _"curraint is damaged and can't be opened"_ error after installation.
-
-Run this command once to remove the quarantine attribute:
+Remove the quarantine attribute once:
 
 ```bash
 xattr -cr /Applications/curraint.app
 ```
 
-Then open the app normally. This is safe, the flag is added automatically by macOS to any app downloaded via a browser and is unrelated to the actual integrity of the binary.
+### CI/CD
 
-## CI/CD pipelines
+The repository includes these GitHub Actions workflows:
 
-- `CI` ([.github/workflows/ci.yml](.github/workflows/ci.yml))
-	- Push or PR to `main`, and manual (`workflow_dispatch`)
-	- Runs `pnpm build` and `pnpm test`
-
-- `Package and Release` ([.github/workflows/package-release.yml](.github/workflows/package-release.yml))
-	- Manual trigger and version tags (`v*`)
-	- Builds packages across Windows/macOS/Linux
-	- Uploads artifacts
-	- On tag builds, creates GitHub Release with attached assets
-
-- `Package Test Artifacts` ([.github/workflows/package-test.yml](.github/workflows/package-test.yml))
-	- Manual trigger with `target` input (`all`, `windows`, `macos`, `linux`)
-	- Builds selected platform packages
-	- Uploads artifacts only (no release)
+- `CI` in `.github/workflows/ci.yml`: runs `pnpm build` and `pnpm test` for pushes, pull requests, and manual triggers.
+- `Package and Release` in `.github/workflows/package-release.yml`: builds release artifacts across Windows, macOS, and Linux, then creates a GitHub release on version tags.
+- `Package Test Artifacts` in `.github/workflows/package-test.yml`: builds selected platform artifacts without creating a release.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding standards, and PR checklist.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding standards, and the PR checklist.
 
 ## Licenses
 
-Third-party dependency licenses are listed in [LICENSES.md](LICENSES.md) (auto-generated during `pnpm build`).
+Third-party dependency licenses are listed in [LICENSES.md](LICENSES.md). The file is generated during `pnpm build`.
 
 ## License
 
 Copyright (C) 2026 Maksym Yemelianov
 
-This program is free software: you can redistribute it and/or modify it under the terms of the [GNU Affero General Public License](LICENSE) as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is free software. You can redistribute it or modify it under the terms of the [GNU Affero General Public License](LICENSE) as published by the Free Software Foundation, either version 3 of the License, or, at your option, any later version.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Most AI chat tools make you choose one surface and live with its tradeoffs. curr
 
 ## Architecture
 
-Yes. GitHub renders Mermaid in README files, and this is a good fit for curraint because the structure is simple and important.
-
 ```mermaid
 flowchart TD
     Desktop["Desktop app<br/>@curraint/desktop"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,26 @@ Behavior notes:
 	- `/edit <number>`, edit a previous user message and regenerate from that point
 	- `Ctrl+C` while streaming, stop current response
 
+## Obsidian plugin
+
+The `packages/obsidian-plugin` package provides an Obsidian plugin that adds a chat sidebar to any Obsidian vault. It uses the same `@curraint/core` chat engine as the desktop and CLI.
+
+**Features:**
+- Chat sidebar powered by `@curraint/core` (streaming, stop, edit/regenerate)
+- Optional "include current note" toggle to inject the active note as context
+- Encrypted API key storage in `data.json` (AES-256-GCM, machine-bound)
+- Provider/model/system-prompt settings via the standard Obsidian settings tab
+
+**Build:**
+
+```bash
+pnpm --filter @curraint/obsidian-plugin build
+```
+
+Output is written to `packages/obsidian-plugin/dist/` (`main.js`, `manifest.json`, `styles.css`). Copy the contents of `dist/` to `.obsidian/plugins/curraint/` inside your vault, then enable the plugin in Obsidian settings.
+
+**Note:** The plugin stores its own encrypted API key separately from the desktop/CLI `secrets.json`. Keys are not shared between the plugin and the desktop/CLI apps.
+
 ## Security
 
 ### API key storage
@@ -171,6 +191,7 @@ Build specific packages:
 pnpm --filter @curraint/core build
 pnpm --filter @curraint/desktop build
 pnpm --filter @curraint/cli build
+pnpm --filter @curraint/obsidian-plugin build
 ```
 
 ## Packaging and releases

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Use **Test Connection** to validate endpoint access before saving.
 ### LM Studio quick setup
 
 - Provider: `LM Studio (Local)`
-- Default base URL: `http://127.0.0.1:1234/v1`
+- Default base URL: `http://127.0.0.1:1234`
 - API key: optional
 
 ## CLI usage
@@ -177,7 +177,7 @@ Behavior notes:
 
 - Uses the same shared chat-session core as the desktop (streaming, stop, edit/regenerate flow).
 - Works with any OpenAI-compatible endpoint configured via environment variables.
-- Conversation history is **not saved by default**. Use `/sessions-save on` to enable persistence; sessions are saved to `settings.json`. Use `/sessions` to browse and resume past conversations once saving is on.
+- Conversation history is **not saved by default**. Use `/sessions-save on` to enable persistence; sessions are stored by the SessionsManager as dedicated JSON files in the app user-data `sessions/` directory, using `<session-id>.json` filenames, while `settings.json` remains config-only. Use `/sessions` to browse and resume saved conversations.
 - Use `Ctrl+C` while streaming to stop the current response.
 
 ## Obsidian plugin

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@curraint/cli",
   "version": "0.1.0",
   "description": "CLI application for curraint",
+  "author": "Maksym Yemelianov",
   "main": "dist/index.js",
   "bin": {
     "curraint": "dist/index.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@curraint/core": "workspace:*",
-    "@github/copilot-sdk": "^0.1.30",
+    "@github/copilot-sdk": "^0.2.0",
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@curraint/core",
   "version": "0.1.0",
   "description": "Shared business logic for curraint",
+  "author": "Maksym Yemelianov",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,6 @@
     "electron-log": "^5.4.3"
   },
   "optionalDependencies": {
-    "@github/copilot-sdk": "^0.1.30"
+    "@github/copilot-sdk": "^0.2.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --out-dir dist",
+    "build": "tsup --config tsup.config.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/core/src/api/copilot/client.test.ts
+++ b/packages/core/src/api/copilot/client.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSdkMock } = vi.hoisted(() => ({
+  getSdkMock: vi.fn()
+}));
+
+vi.mock('./sdk', () => ({
+  getSdk: getSdkMock
+}));
+
+describe('copilot client lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('restarts the singleton when the cached client is disconnected', async () => {
+    const staleClient = {
+      getState: vi.fn().mockReturnValue('disconnected'),
+      ping: vi.fn(),
+      stop: vi.fn().mockResolvedValue([])
+    };
+
+    const healthyClient = {
+      getState: vi.fn().mockReturnValue('connected'),
+      ping: vi.fn().mockResolvedValue({ message: 'ok', timestamp: Date.now() }),
+      stop: vi.fn().mockResolvedValue([])
+    };
+
+    const CopilotClient = vi
+      .fn()
+      .mockReturnValueOnce(staleClient)
+      .mockReturnValueOnce(healthyClient);
+
+    getSdkMock.mockResolvedValue({ CopilotClient });
+
+    const clientModule = await import('./client');
+
+    expect(await clientModule.getClient()).toBe(staleClient);
+    expect(await clientModule.getClient()).toBe(healthyClient);
+
+    expect(staleClient.stop).toHaveBeenCalledOnce();
+    expect(healthyClient.ping).not.toHaveBeenCalled();
+    expect(CopilotClient).toHaveBeenNthCalledWith(1, {
+      useLoggedInUser: true,
+      useStdio: false
+    });
+    expect(CopilotClient).toHaveBeenNthCalledWith(2, {
+      useLoggedInUser: true,
+      useStdio: false
+    });
+  });
+
+  it('restarts the singleton when the cached client fails a health ping', async () => {
+    const staleClient = {
+      getState: vi.fn().mockReturnValue('connected'),
+      ping: vi.fn().mockRejectedValue(new Error('socket closed')),
+      stop: vi.fn().mockResolvedValue([])
+    };
+
+    const healthyClient = {
+      getState: vi.fn().mockReturnValue('connected'),
+      ping: vi.fn().mockResolvedValue({ message: 'ok', timestamp: Date.now() }),
+      stop: vi.fn().mockResolvedValue([])
+    };
+
+    const CopilotClient = vi
+      .fn()
+      .mockReturnValueOnce(staleClient)
+      .mockReturnValueOnce(healthyClient);
+
+    getSdkMock.mockResolvedValue({ CopilotClient });
+
+    const clientModule = await import('./client');
+
+    expect(await clientModule.getClient()).toBe(staleClient);
+    expect(await clientModule.getClient()).toBe(healthyClient);
+
+    expect(staleClient.ping).toHaveBeenCalledOnce();
+    expect(staleClient.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/api/copilot/client.ts
+++ b/packages/core/src/api/copilot/client.ts
@@ -15,16 +15,59 @@ function stripConflictingEnvVars(): void {
   for (const key of ENV_KEYS_TO_STRIP) delete process.env[key];
 }
 
+const COPILOT_CLIENT_OPTIONS = {
+  useLoggedInUser: true,
+  useStdio: false
+} as const;
+
+function isClientConnected(client: CopilotClientType): boolean {
+  return client.getState() === 'connected';
+}
+
+async function isClientHealthy(client: CopilotClientType): Promise<boolean> {
+  if (!isClientConnected(client)) return false;
+
+  try {
+    await client.ping('health check');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createClient(): Promise<CopilotClientType> {
+  const { CopilotClient } = await getSdk();
+  stripConflictingEnvVars();
+  return new CopilotClient(COPILOT_CLIENT_OPTIONS);
+}
+
+async function replaceClientInstance(): Promise<CopilotClientType> {
+  const staleClient = clientInstance;
+  clientInstance = null;
+
+  if (staleClient) {
+    await staleClient.stop().catch(() => {});
+  }
+
+  const freshClient = await createClient();
+  clientInstance = freshClient;
+  return freshClient;
+}
+
 // Singleton CopilotClient — spawns the CLI subprocess once and reuses it.
 let clientInstance: CopilotClientType | null = null;
 
 export async function getClient(): Promise<CopilotClientType> {
   if (!clientInstance) {
-    const { CopilotClient } = await getSdk();
-    stripConflictingEnvVars();
     // Use TCP instead of stdio so Electron's pipe interception doesn't break the channel.
-    clientInstance = new CopilotClient({ useLoggedInUser: true, useStdio: false });
+    clientInstance = await createClient();
+    return clientInstance;
   }
+
+  if (!(await isClientHealthy(clientInstance))) {
+    return replaceClientInstance();
+  }
+
   return clientInstance;
 }
 

--- a/packages/core/src/api/copilot/client.ts
+++ b/packages/core/src/api/copilot/client.ts
@@ -23,7 +23,7 @@ export async function getClient(): Promise<CopilotClientType> {
     const { CopilotClient } = await getSdk();
     stripConflictingEnvVars();
     // Use TCP instead of stdio so Electron's pipe interception doesn't break the channel.
-    clientInstance = new CopilotClient({ useLoggedInUser: true, autoRestart: true, useStdio: false });
+    clientInstance = new CopilotClient({ useLoggedInUser: true, useStdio: false });
   }
   return clientInstance;
 }

--- a/packages/core/src/api/copilot/lifecycle.ts
+++ b/packages/core/src/api/copilot/lifecycle.ts
@@ -32,7 +32,7 @@ export async function copilotTestConnection(model: string): Promise<string> {
   });
   try {
     await session.sendAndWait({ prompt: 'Say "OK" and nothing else.' }, 15000);
-    await session.disconnect();
+    await session.disconnect().catch(() => {});
     return 'Connection successful. GitHub Copilot is ready.';
   } catch (error) {
     await session.disconnect().catch(() => {});

--- a/packages/core/src/api/copilot/lifecycle.ts
+++ b/packages/core/src/api/copilot/lifecycle.ts
@@ -32,10 +32,10 @@ export async function copilotTestConnection(model: string): Promise<string> {
   });
   try {
     await session.sendAndWait({ prompt: 'Say "OK" and nothing else.' }, 15000);
-    await session.destroy();
+    await session.disconnect();
     return 'Connection successful. GitHub Copilot is ready.';
   } catch (error) {
-    await session.destroy().catch(() => {});
+    await session.disconnect().catch(() => {});
     throw error;
   }
 }

--- a/packages/core/src/api/copilot/lifecycle.ts
+++ b/packages/core/src/api/copilot/lifecycle.ts
@@ -1,6 +1,6 @@
 import { getClient, stopClient } from './client';
 import { getSdk } from './sdk';
-import { destroyActiveSession, getOrCreateSession } from './session';
+import { disconnectActiveSession, getOrCreateSession } from './session';
 
 /** Pre-warm: eagerly start the CLI and create the session to reduce cold-start overhead. */
 export async function warmupCopilotSession(
@@ -19,7 +19,7 @@ export async function resetCopilotSession(
   model: string,
   systemPrompt: string
 ): Promise<void> {
-  await destroyActiveSession();
+  await disconnectActiveSession();
   await warmupCopilotSession(model, systemPrompt);
 }
 
@@ -41,6 +41,6 @@ export async function copilotTestConnection(model: string): Promise<string> {
 }
 
 export async function stopCopilotClient(): Promise<void> {
-  await destroyActiveSession();
+  await disconnectActiveSession();
   await stopClient();
 }

--- a/packages/core/src/api/copilot/session.test.ts
+++ b/packages/core/src/api/copilot/session.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getClientMock, getSdkMock } = vi.hoisted(() => ({
+  getClientMock: vi.fn(),
+  getSdkMock: vi.fn()
+}));
+
+vi.mock('./client', () => ({
+  getClient: getClientMock
+}));
+
+vi.mock('./sdk', () => ({
+  getSdk: getSdkMock
+}));
+
+describe('copilot session lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('drops the cached session when the client singleton is replaced', async () => {
+    const firstSession = {
+      disconnect: vi.fn().mockResolvedValue(undefined)
+    };
+    const secondSession = {
+      disconnect: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const firstClient = {
+      createSession: vi.fn().mockResolvedValue(firstSession)
+    };
+    const secondClient = {
+      createSession: vi.fn().mockResolvedValue(secondSession)
+    };
+
+    getClientMock.mockResolvedValueOnce(firstClient).mockResolvedValueOnce(secondClient);
+    getSdkMock.mockResolvedValue({ approveAll: vi.fn() });
+
+    const sessionModule = await import('./session');
+
+    const originalSession = await sessionModule.getOrCreateSession('gpt-4o', 'system', false);
+    const restartedSession = await sessionModule.getOrCreateSession('gpt-4o', 'system', false);
+
+    expect(originalSession).toBe(firstSession);
+    expect(restartedSession).toBe(secondSession);
+    expect(firstSession.disconnect).toHaveBeenCalledOnce();
+    expect(firstClient.createSession).toHaveBeenCalledOnce();
+    expect(secondClient.createSession).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/api/copilot/session.ts
+++ b/packages/core/src/api/copilot/session.ts
@@ -7,6 +7,17 @@ import type { SessionState } from './types';
 // Recreated when model/system prompt changes or when explicitly reset.
 export let activeSession: SessionState | null = null;
 
+/**
+ * Gently disconnects the current SDK session before clearing the local cache.
+ * The SDK handles the underlying teardown and any reconnectable state.
+ */
+export async function disconnectActiveSession(): Promise<void> {
+  if (activeSession) {
+    await activeSession.session.disconnect().catch(() => {});
+    activeSession = null;
+  }
+}
+
 function isSessionStale(model: string, systemPrompt: string, forceNew: boolean): boolean {
   if (!activeSession) return true;
   const settingsChanged =
@@ -30,13 +41,6 @@ async function createNewSession(
   });
 }
 
-export async function destroyActiveSession(): Promise<void> {
-  if (activeSession) {
-    await activeSession.session.disconnect().catch(() => {});
-    activeSession = null;
-  }
-}
-
 export async function getOrCreateSession(
   model: string,
   systemPrompt: string,
@@ -45,10 +49,10 @@ export async function getOrCreateSession(
   const client = await getClient();
 
   if (activeSession?.client !== client) {
-    await destroyActiveSession();
+    await disconnectActiveSession();
   }
 
-  if (isSessionStale(model, systemPrompt, forceNew)) await destroyActiveSession();
+  if (isSessionStale(model, systemPrompt, forceNew)) await disconnectActiveSession();
 
   if (!activeSession) {
     const session = await createNewSession(client, model, systemPrompt);

--- a/packages/core/src/api/copilot/session.ts
+++ b/packages/core/src/api/copilot/session.ts
@@ -15,11 +15,11 @@ function isSessionStale(model: string, systemPrompt: string, forceNew: boolean):
 }
 
 async function createNewSession(
+  client: Awaited<ReturnType<typeof getClient>>,
   model: string,
   systemPrompt: string
 ): Promise<CopilotSessionType> {
   const { approveAll } = await getSdk();
-  const client = await getClient();
   return client.createSession({
     model: model || 'gpt-4o',
     streaming: true,
@@ -42,10 +42,17 @@ export async function getOrCreateSession(
   systemPrompt: string,
   forceNew: boolean
 ): Promise<CopilotSessionType> {
+  const client = await getClient();
+
+  if (activeSession?.client !== client) {
+    await destroyActiveSession();
+  }
+
   if (isSessionStale(model, systemPrompt, forceNew)) await destroyActiveSession();
+
   if (!activeSession) {
-    const session = await createNewSession(model, systemPrompt);
-    activeSession = { session, model, systemPrompt, messageCount: 0 };
+    const session = await createNewSession(client, model, systemPrompt);
+    activeSession = { client, session, model, systemPrompt, messageCount: 0 };
   }
   return activeSession.session;
 }

--- a/packages/core/src/api/copilot/session.ts
+++ b/packages/core/src/api/copilot/session.ts
@@ -32,7 +32,7 @@ async function createNewSession(
 
 export async function destroyActiveSession(): Promise<void> {
   if (activeSession) {
-    await activeSession.session.destroy().catch(() => {});
+    await activeSession.session.disconnect().catch(() => {});
     activeSession = null;
   }
 }
@@ -53,7 +53,7 @@ export async function getOrCreateSession(
 /** Invalidates the active session if it matches the given session instance. */
 export async function invalidateSession(session: CopilotSessionType): Promise<void> {
   if (activeSession?.session === session) {
-    await session.destroy().catch(() => {});
+    await session.disconnect().catch(() => {});
     activeSession = null;
   }
 }

--- a/packages/core/src/api/copilot/types.ts
+++ b/packages/core/src/api/copilot/types.ts
@@ -11,6 +11,7 @@ export type Sdk = {
 };
 
 export type SessionState = {
+  client: CopilotClientType;
   session: CopilotSessionType;
   model: string;
   systemPrompt: string;

--- a/packages/core/src/api/openai/client.test.ts
+++ b/packages/core/src/api/openai/client.test.ts
@@ -9,7 +9,8 @@ const validSettings: EndpointSettings = {
   model: 'test-model',
   systemPrompt: '',
   contextMaxMessages: 40,
-  contextMaxCharacters: 24000
+  contextMaxCharacters: 24000,
+  enableSessionSaving: false,
 };
 
 afterEach(() => {

--- a/packages/core/src/api/openai/client.ts
+++ b/packages/core/src/api/openai/client.ts
@@ -8,6 +8,7 @@ import {
   readErrorDetail,
   validateSettingsForRequest
 } from './request';
+import { buildOpenAiPayload } from './payload';
 import { readStreamingCompletion } from './streaming';
 import type { CompletionResponse, StreamCallbacks, StreamOptions } from './types';
 
@@ -30,8 +31,7 @@ export async function chatCompletion(
   const baseUrl = validateSettingsForRequest(settings);
   const url = `${baseUrl}/chat/completions`;
   const headers = createAuthHeaders(settings);
-  const apiMessages = messages.map(({ role, content }) => ({ role, content }));
-  const body = { model: settings.model.trim(), messages: apiMessages };
+  const body = buildOpenAiPayload(settings, messages);
   logRequest('', url, headers, body);
   const response = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
   logResponse(response);
@@ -52,10 +52,7 @@ export async function chatCompletionStream(
   const baseUrl = validateSettingsForRequest(settings);
   const url = `${baseUrl}/chat/completions`;
   const headers = createAuthHeaders(settings);
-  const apiMessages = messages.map(({ role, content }) => ({ role, content }));
-  const supportsStreamOptions = settings.provider === 'openai' || settings.provider === 'copilot';
-  const body: Record<string, unknown> = { model: settings.model.trim(), messages: apiMessages, stream: true };
-  if (supportsStreamOptions) body.stream_options = { include_usage: true };
+  const body = buildOpenAiPayload(settings, messages, { stream: true });
   logRequest('(stream)', url, headers, body);
   const response = await fetch(url, { method: 'POST', headers, signal: options.signal, body: JSON.stringify(body) });
   logResponse(response);

--- a/packages/core/src/api/openai/client.ts
+++ b/packages/core/src/api/openai/client.ts
@@ -30,7 +30,8 @@ export async function chatCompletion(
   const baseUrl = validateSettingsForRequest(settings);
   const url = `${baseUrl}/chat/completions`;
   const headers = createAuthHeaders(settings);
-  const body = { model: settings.model.trim(), messages };
+  const apiMessages = messages.map(({ role, content }) => ({ role, content }));
+  const body = { model: settings.model.trim(), messages: apiMessages };
   logRequest('', url, headers, body);
   const response = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
   logResponse(response);
@@ -51,7 +52,10 @@ export async function chatCompletionStream(
   const baseUrl = validateSettingsForRequest(settings);
   const url = `${baseUrl}/chat/completions`;
   const headers = createAuthHeaders(settings);
-  const body = { model: settings.model.trim(), messages, stream: true, stream_options: { include_usage: true } };
+  const apiMessages = messages.map(({ role, content }) => ({ role, content }));
+  const supportsStreamOptions = settings.provider === 'openai' || settings.provider === 'copilot';
+  const body: Record<string, unknown> = { model: settings.model.trim(), messages: apiMessages, stream: true };
+  if (supportsStreamOptions) body.stream_options = { include_usage: true };
   logRequest('(stream)', url, headers, body);
   const response = await fetch(url, { method: 'POST', headers, signal: options.signal, body: JSON.stringify(body) });
   logResponse(response);

--- a/packages/core/src/api/openai/payload.test.ts
+++ b/packages/core/src/api/openai/payload.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { EndpointSettings } from '../../settings/types';
+import { buildOpenAiPayload, sanitizeOpenAiMessages, supportsOpenAiStreamOptions } from './payload';
+
+const baseSettings: EndpointSettings = {
+  provider: 'openai',
+  apiKey: 'test-key',
+  baseUrl: 'https://api.example.com',
+  model: '  test-model  ',
+  systemPrompt: '',
+  contextMaxMessages: 40,
+  contextMaxCharacters: 24000,
+  enableSessionSaving: false,
+};
+
+describe('sanitizeOpenAiMessages', () => {
+  it('keeps only role and content fields', () => {
+    expect(
+      sanitizeOpenAiMessages([
+        {
+          role: 'user',
+          content: 'Hello',
+          timestamp: 123,
+          durationMs: 456,
+          usage: { total_tokens: 10 },
+        },
+      ])
+    ).toEqual([{ role: 'user', content: 'Hello' }]);
+  });
+});
+
+describe('supportsOpenAiStreamOptions', () => {
+  it('enables usage stream options only for supported providers', () => {
+    expect(supportsOpenAiStreamOptions('openai')).toBe(true);
+    expect(supportsOpenAiStreamOptions('copilot')).toBe(true);
+    expect(supportsOpenAiStreamOptions('custom')).toBe(false);
+    expect(supportsOpenAiStreamOptions('lmstudio')).toBe(false);
+  });
+});
+
+describe('buildOpenAiPayload', () => {
+  it('trims the model and sanitizes messages for non-streaming requests', () => {
+    expect(
+      buildOpenAiPayload(baseSettings, [
+        {
+          role: 'assistant',
+          content: 'Done',
+          timestamp: 1,
+          durationMs: 2,
+        },
+      ])
+    ).toEqual({
+      model: 'test-model',
+      messages: [{ role: 'assistant', content: 'Done' }],
+    });
+  });
+
+  it('adds usage stream options only for providers that support them', () => {
+    expect(
+      buildOpenAiPayload(baseSettings, [{ role: 'user', content: 'Hi' }], { stream: true })
+    ).toEqual({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+
+    expect(
+      buildOpenAiPayload(
+        { ...baseSettings, provider: 'custom' },
+        [{ role: 'user', content: 'Hi' }],
+        { stream: true }
+      )
+    ).toEqual({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+  });
+});

--- a/packages/core/src/api/openai/payload.test.ts
+++ b/packages/core/src/api/openai/payload.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ChatMessage } from '../../types';
 import type { EndpointSettings } from '../../settings/types';
 import { buildOpenAiPayload, sanitizeOpenAiMessages, supportsOpenAiStreamOptions } from './payload';
 
@@ -26,6 +27,18 @@ describe('sanitizeOpenAiMessages', () => {
         },
       ])
     ).toEqual([{ role: 'user', content: 'Hello' }]);
+  });
+
+  it('preserves empty strings and normalizes undefined content to empty strings', () => {
+    const messages = [
+      { role: 'user', content: '', timestamp: 123 },
+      { role: 'assistant', content: undefined, usage: { total_tokens: 1 } },
+    ] as unknown as ChatMessage[];
+
+    expect(sanitizeOpenAiMessages(messages)).toEqual([
+      { role: 'user', content: '' },
+      { role: 'assistant', content: '' },
+    ]);
   });
 });
 

--- a/packages/core/src/api/openai/payload.ts
+++ b/packages/core/src/api/openai/payload.ts
@@ -16,12 +16,14 @@ type OpenAiPayloadOptions = {
   stream?: boolean;
 };
 
+const STREAM_OPTIONS_PROVIDERS = new Set<EndpointSettings['provider']>(['openai', 'copilot']);
+
 export function sanitizeOpenAiMessages(messages: ChatMessage[]): OpenAiApiMessage[] {
-  return messages.map(({ role, content }) => ({ role, content }));
+  return messages.map(({ role, content }) => ({ role, content: content ?? '' }));
 }
 
 export function supportsOpenAiStreamOptions(provider: EndpointSettings['provider']): boolean {
-  return provider === 'openai' || provider === 'copilot';
+  return STREAM_OPTIONS_PROVIDERS.has(provider);
 }
 
 export function buildOpenAiPayload(

--- a/packages/core/src/api/openai/payload.ts
+++ b/packages/core/src/api/openai/payload.ts
@@ -1,0 +1,47 @@
+import type { ChatMessage } from '../../types';
+import type { EndpointSettings } from '../../settings/types';
+
+type OpenAiApiMessage = Pick<ChatMessage, 'role' | 'content'>;
+
+export type OpenAiPayload = {
+  model: string;
+  messages: OpenAiApiMessage[];
+  stream?: true;
+  stream_options?: {
+    include_usage: true;
+  };
+};
+
+type OpenAiPayloadOptions = {
+  stream?: boolean;
+};
+
+export function sanitizeOpenAiMessages(messages: ChatMessage[]): OpenAiApiMessage[] {
+  return messages.map(({ role, content }) => ({ role, content }));
+}
+
+export function supportsOpenAiStreamOptions(provider: EndpointSettings['provider']): boolean {
+  return provider === 'openai' || provider === 'copilot';
+}
+
+export function buildOpenAiPayload(
+  settings: EndpointSettings,
+  messages: ChatMessage[],
+  options: OpenAiPayloadOptions = {}
+): OpenAiPayload {
+  const payload: OpenAiPayload = {
+    model: settings.model.trim(),
+    messages: sanitizeOpenAiMessages(messages),
+  };
+
+  if (!options.stream) {
+    return payload;
+  }
+
+  payload.stream = true;
+  if (supportsOpenAiStreamOptions(settings.provider)) {
+    payload.stream_options = { include_usage: true };
+  }
+
+  return payload;
+}

--- a/packages/core/src/providers/configs.ts
+++ b/packages/core/src/providers/configs.ts
@@ -14,7 +14,7 @@ export const PROVIDER_CONFIGS: Record<ProviderId, ProviderConfig> = {
   lmstudio: {
     id: 'lmstudio',
     label: 'LM Studio (Local)',
-    defaultBaseUrl: 'http://127.0.0.1:1234/v1',
+    defaultBaseUrl: 'http://127.0.0.1:1234',
     defaultModel: 'local-model',
     requiresApiKey: false,
     requiresBaseUrl: true

--- a/packages/core/src/providers/providers.test.ts
+++ b/packages/core/src/providers/providers.test.ts
@@ -23,7 +23,7 @@ describe('provider configs', () => {
 
   it('returns provider config by id', () => {
     expect(getProviderConfig('openai').label).toBe('OpenAI (Cloud)');
-    expect(getProviderConfig('lmstudio').defaultBaseUrl).toBe('http://127.0.0.1:1234/v1');
+    expect(getProviderConfig('lmstudio').defaultBaseUrl).toBe('http://127.0.0.1:1234');
   });
 
   it('applies expected API key requirements', () => {

--- a/packages/core/src/secrets/key-derivation.ts
+++ b/packages/core/src/secrets/key-derivation.ts
@@ -3,7 +3,7 @@ import os from 'os';
 
 const KEY_LEN = 32;
 const KDF_SALT = 'curraint-secrets-v1';
-const KDF_ITERATIONS = 100_000;
+const KDF_ITERATIONS = 600_000;
 
 let _cachedKey: Buffer | undefined;
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,8 +10,9 @@
     "resolveJsonModule": true,
     "outDir": "dist",
     "declarationDir": "dist",
+    "composite": true,
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/*.ts", "src/**/*.ts"]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  outDir: 'dist',
+  dts: {
+    compilerOptions: {
+      composite: false
+    }
+  }
+});

--- a/packages/desktop-e2e/package.json
+++ b/packages/desktop-e2e/package.json
@@ -2,6 +2,7 @@
   "name": "@curraint/desktop-e2e",
   "version": "0.1.0",
   "description": "Playwright e2e tests for the curraint desktop app",
+  "author": "Maksym Yemelianov",
   "private": true,
   "scripts": {
     "e2e": "playwright test",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Desktop application for curraint (macOS/Linux/Windows)",
   "author": {
-    "name": "curraint",
+    "name": "Maksym Yemelianov",
     "email": "curraint@users.noreply.github.com"
   },
   "homepage": "https://github.com/curraint/curraint",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@curraint/core": "workspace:*",
-    "@github/copilot-sdk": "^0.1.30",
+    "@github/copilot-sdk": "^0.2.0",
     "electron-log": "^5.4.3",
     "highlight.js": "^11.11.1",
     "react-markdown": "^10.1.0",
@@ -64,7 +64,13 @@
     },
     "mac": {
       "target": [
-        { "target": "dmg", "arch": ["arm64", "x64"] }
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
       ],
       "identity": null
     },

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -1,7 +1,7 @@
 import esbuild from 'esbuild';
 import builtins from 'builtin-modules';
-import process from 'process';
-import fs from 'fs';
+import process from 'node:process';
+import fs from 'node:fs';
 
 const isWatch = process.argv.includes('--watch');
 const isDev = isWatch;

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -1,0 +1,49 @@
+import esbuild from 'esbuild';
+import builtins from 'builtin-modules';
+import process from 'process';
+import fs from 'fs';
+
+const isWatch = process.argv.includes('--watch');
+
+function copyStaticFiles() {
+  fs.mkdirSync('dist', { recursive: true });
+  fs.copyFileSync('manifest.json', 'dist/manifest.json');
+  fs.copyFileSync('styles.css', 'dist/styles.css');
+}
+
+const buildOptions = {
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  external: [
+    'obsidian',
+    'electron',
+    '@codemirror/autocomplete',
+    '@codemirror/collab',
+    '@codemirror/commands',
+    '@codemirror/language',
+    '@codemirror/lint',
+    '@codemirror/search',
+    '@codemirror/state',
+    '@codemirror/view',
+    '@lezer/common',
+    '@lezer/highlight',
+    '@lezer/lr',
+    ...builtins,
+  ],
+  format: 'cjs',
+  target: 'es2018',
+  logLevel: 'info',
+  sourcemap: 'inline',
+  treeShaking: true,
+  outfile: 'dist/main.js',
+};
+
+if (isWatch) {
+  copyStaticFiles();
+  const ctx = await esbuild.context(buildOptions);
+  await ctx.watch();
+  console.log('Watching for changes...');
+} else {
+  await esbuild.build(buildOptions);
+  copyStaticFiles();
+}

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -4,6 +4,7 @@ import process from 'process';
 import fs from 'fs';
 
 const isWatch = process.argv.includes('--watch');
+const isDev = isWatch;
 
 function copyStaticFiles() {
   fs.mkdirSync('dist', { recursive: true });
@@ -35,6 +36,9 @@ const buildOptions = {
   logLevel: 'info',
   sourcemap: 'inline',
   treeShaking: true,
+  define: {
+    __DEV__: String(isDev),
+  },
   outfile: 'dist/main.js',
 };
 

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -8,8 +8,14 @@ const isDev = process.argv.includes('--dev') || isWatch;
 
 function copyStaticFiles() {
   fs.mkdirSync('dist', { recursive: true });
-  fs.copyFileSync('manifest.json', 'dist/manifest.json');
-  fs.copyFileSync('styles.css', 'dist/styles.css');
+  for (const fileName of ['manifest.json', 'styles.css']) {
+    if (!fs.existsSync(fileName)) {
+      console.warn(`Curraint: Skipping missing static file ${fileName}`);
+      continue;
+    }
+
+    fs.copyFileSync(fileName, `dist/${fileName}`);
+  }
 }
 
 const buildOptions = {

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -4,7 +4,7 @@ import process from 'node:process';
 import fs from 'node:fs';
 
 const isWatch = process.argv.includes('--watch');
-const isDev = isWatch;
+const isDev = process.argv.includes('--dev') || isWatch;
 
 function copyStaticFiles() {
   fs.mkdirSync('dist', { recursive: true });

--- a/packages/obsidian-plugin/manifest.json
+++ b/packages/obsidian-plugin/manifest.json
@@ -6,6 +6,6 @@
   "description": "Chat with AI from within Obsidian. Optionally include the current note as context.",
   "author": "Maksym Yemelianov",
   "authorUrl": "",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }
 

--- a/packages/obsidian-plugin/manifest.json
+++ b/packages/obsidian-plugin/manifest.json
@@ -1,0 +1,11 @@
+{
+  "id": "curraint",
+  "name": "Curraint AI Chat",
+  "version": "0.1.0",
+  "minAppVersion": "1.4.0",
+  "description": "Chat with AI from within Obsidian. Optionally include the current note as context.",
+  "author": "Maksym Yemelianov",
+  "authorUrl": "",
+  "isDesktopOnly": true
+}
+

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@curraint/obsidian-plugin",
+  "version": "0.1.0",
+  "description": "Obsidian plugin for curraint AI chat",
+  "author": "Maksym Yemelianov",
+  "private": true,
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "dev": "node esbuild.config.mjs --watch",
+    "deploy": "node esbuild.config.mjs && node scripts/deploy.mjs",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@curraint/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "builtin-modules": "^4.0.0",
+    "esbuild": "^0.25.0",
+    "jsdom": "^26.0.0",
+    "obsidian": "^1.7.7",
+    "typescript": "^5.8.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/obsidian-plugin/scripts/deploy.mjs
+++ b/packages/obsidian-plugin/scripts/deploy.mjs
@@ -10,9 +10,9 @@
  * The script writes to <vault>/.obsidian/plugins/curraint/
  */
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgRoot = path.join(__dirname, '..');

--- a/packages/obsidian-plugin/scripts/deploy.mjs
+++ b/packages/obsidian-plugin/scripts/deploy.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Copies the built plugin files from dist/ into a local Obsidian vault for testing.
+ *
+ * Setup (one-time):
+ *   Create packages/obsidian-plugin/.vault-path containing the absolute path to
+ *   your Obsidian vault root, e.g.:
+ *     C:\Users\you\Documents\MyVault
+ *
+ * The script writes to <vault>/.obsidian/plugins/curraint/
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.join(__dirname, '..');
+const vaultPathFile = path.join(pkgRoot, '.vault-path');
+
+if (!fs.existsSync(vaultPathFile)) {
+  console.error(
+    'Missing .vault-path file.\n' +
+    'Create packages/obsidian-plugin/.vault-path with the absolute path to your\n' +
+    'Obsidian vault root (e.g. C:\\Users\\you\\Documents\\MyVault).'
+  );
+  process.exit(1);
+}
+
+const vaultRoot = fs.readFileSync(vaultPathFile, 'utf8').trim();
+if (!fs.existsSync(vaultRoot)) {
+  console.error(`Vault path does not exist: ${vaultRoot}`);
+  process.exit(1);
+}
+
+const dest = path.join(vaultRoot, '.obsidian', 'plugins', 'curraint');
+fs.mkdirSync(dest, { recursive: true });
+
+const files = ['main.js', 'styles.css'];
+for (const file of files) {
+  const src = path.join(pkgRoot, 'dist', file);
+  if (!fs.existsSync(src)) {
+    console.error(`Built file not found: ${src}\nRun the build first.`);
+    process.exit(1);
+  }
+  fs.copyFileSync(src, path.join(dest, file));
+  console.log(`  copied ${file}`);
+}
+
+// Append a random suffix on local builds so each deploy is distinguishable
+// in Obsidian. CI environments set the CI variable, so skip the suffix there.
+const manifestSrc = path.join(pkgRoot, 'manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestSrc, 'utf8'));
+if (!process.env.CI) {
+  const buildId = Math.random().toString(36).slice(2, 6);
+  manifest.version = `${manifest.version}-${buildId}`;
+}
+fs.writeFileSync(path.join(dest, 'manifest.json'), JSON.stringify(manifest, null, 2));
+console.log(`  wrote manifest.json (version: ${manifest.version})`);
+
+console.log(`\nDeployed to ${dest}`);

--- a/packages/obsidian-plugin/src/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/src/__mocks__/obsidian.ts
@@ -25,3 +25,10 @@ export class Modal {}
 export class Setting {}
 export class PluginSettingTab {}
 export function setIcon(_el: HTMLElement, _icon: string): void {}
+
+export const Platform = {
+  isMobile: false,
+  isDesktop: true,
+  isPhone: false,
+  isTablet: false,
+};

--- a/packages/obsidian-plugin/src/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/src/__mocks__/obsidian.ts
@@ -1,0 +1,27 @@
+// Minimal stub for the 'obsidian' module in test environments.
+// The real module is provided at runtime by the Obsidian host and is
+// marked external in the esbuild config, so it cannot be resolved by vitest.
+// Tests that import from 'obsidian' should use vi.mock('obsidian', ...) to
+// override specific symbols.
+
+export class MarkdownRenderer {
+  static async render(
+    _app: unknown,
+    markdown: string,
+    el: HTMLElement,
+    _sourcePath: string,
+    _component: unknown,
+  ): Promise<void> {
+    el.textContent = markdown;
+  }
+}
+
+export class Plugin {}
+export class ItemView {}
+export class Notice {
+  constructor(_message: string) {}
+}
+export class Modal {}
+export class Setting {}
+export class PluginSettingTab {}
+export function setIcon(_el: HTMLElement, _icon: string): void {}

--- a/packages/obsidian-plugin/src/chat/chat-view.ts
+++ b/packages/obsidian-plugin/src/chat/chat-view.ts
@@ -93,7 +93,11 @@ export class ChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
-    this.registry.destroy();
+    this.destroyRegistry();
+  }
+
+  destroyRegistry(): void {
+    this.registry?.destroy();
   }
 
   injectCurrentNote(): void {

--- a/packages/obsidian-plugin/src/chat/chat-view.ts
+++ b/packages/obsidian-plugin/src/chat/chat-view.ts
@@ -1,0 +1,259 @@
+import { ItemView, Notice, WorkspaceLeaf, setIcon } from 'obsidian';
+import type CurraintPlugin from '../main';
+import { buildTransport } from '../transport';
+import { buildNoteContextMessage } from '../note-context';
+import { ConversationRegistry } from './session-manager';
+import { MessageRenderer } from './message-renderer';
+import { InputBar } from './input-bar';
+import { SessionsModal } from './sessions-modal';
+import type { ChatMessage, ChatSessionCore, SavedSession } from '@curraint/core';
+
+export const CHAT_VIEW_TYPE = 'curraint-chat';
+
+export class ChatView extends ItemView {
+  private readonly plugin: CurraintPlugin;
+  private registry!: ConversationRegistry;
+  private messageRenderer!: MessageRenderer;
+  private inputBar!: InputBar;
+  private noteContextActive = false;
+
+  constructor(leaf: WorkspaceLeaf, plugin: CurraintPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return CHAT_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return 'Curraint Chat';
+  }
+
+  getIcon(): string {
+    return 'message-circle';
+  }
+
+  async onOpen(): Promise<void> {
+    const root = this.containerEl.children[1] as HTMLElement;
+    root.className = 'curraint-chat-view';
+
+    const header = document.createElement('div');
+    header.className = 'curraint-chat-header';
+
+    const formatToggle = document.createElement('button');
+    formatToggle.className = 'curraint-chat-header__format-toggle';
+    formatToggle.title = 'Switch to plain text';
+    formatToggle.setAttribute('aria-label', 'Switch to plain text');
+    setIcon(formatToggle, 'pilcrow');
+    formatToggle.addEventListener('click', () => {
+      const plain = !this.messageRenderer.isPlainMode;
+      this.messageRenderer.setPlainMode(plain);
+      if (plain) {
+        setIcon(formatToggle, 'code');
+        formatToggle.title = 'Switch to formatted view';
+        formatToggle.setAttribute('aria-label', 'Switch to formatted view');
+      } else {
+        setIcon(formatToggle, 'pilcrow');
+        formatToggle.title = 'Switch to plain text';
+        formatToggle.setAttribute('aria-label', 'Switch to plain text');
+      }
+    });
+    header.appendChild(formatToggle);
+
+    const newChatBtn = document.createElement('button');
+    newChatBtn.className = 'curraint-chat-header__new-chat';
+    newChatBtn.title = 'New conversation';
+    newChatBtn.setAttribute('aria-label', 'New conversation');
+    newChatBtn.textContent = 'Start a new conversation';
+    newChatBtn.addEventListener('click', () => this.handleNewConversation());
+    header.appendChild(newChatBtn);
+
+    const sessionsBtn = document.createElement('button');
+    sessionsBtn.className = 'curraint-chat-header__sessions';
+    sessionsBtn.title = 'Browse saved conversations';
+    sessionsBtn.setAttribute('aria-label', 'Browse saved conversations');
+    sessionsBtn.textContent = 'Conversations';
+    sessionsBtn.addEventListener('click', () => this.handleOpenSessions());
+    header.appendChild(sessionsBtn);
+    root.appendChild(header);
+
+    const messagesEl = document.createElement('div');
+    messagesEl.className = 'curraint-messages';
+    root.appendChild(messagesEl);
+
+    const inputEl = document.createElement('div');
+    root.appendChild(inputEl);
+
+    this.messageRenderer = new MessageRenderer(messagesEl, this.app, this);
+    this.registry = new ConversationRegistry(
+      () => buildTransport(this.plugin),
+      () => this.plugin.settings.enableSessionSaving
+    );
+    this.registry.init();
+
+    this.inputBar = new InputBar(inputEl, {
+      onSubmit: (text) => { void this.handleSubmit(text); },
+      onNoteToggle: (active) => { void this.handleNoteToggle(active); },
+      onStop: () => { this.registry.stopActive(); },
+    });
+
+    this.inputBar.focus();
+  }
+
+  async onClose(): Promise<void> {
+    this.registry.destroy();
+  }
+
+  async injectCurrentNote(): Promise<void> {
+    const file = this.plugin.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice('Curraint: No active note to add as context.');
+      return;
+    }
+    this.noteContextActive = true;
+    this.inputBar.setNoteActive(true, file.basename);
+  }
+
+  private handleNewConversation(): void {
+    this.registry.newConversation();
+    this.messageRenderer.renderAll([]);
+    this.inputBar.setLoading(false);
+    this.noteContextActive = false;
+    this.inputBar.setNoteActive(false);
+    this.inputBar.focus();
+  }
+
+  private handleNoteToggle(active: boolean): void {
+    if (!active) {
+      this.noteContextActive = false;
+      return;
+    }
+    const file = this.plugin.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice('Curraint: No active note to add as context.');
+      this.inputBar.setNoteActive(false);
+      return;
+    }
+    this.noteContextActive = true;
+    this.inputBar.setNoteActive(true, file.basename);
+  }
+
+  private async handleSubmit(text: string): Promise<void> {
+    const core = this.registry.getOrCreateActive();
+    const submissionKey = this.registry.activeKey;
+    const isThisConvActive = (): boolean => this.registry.activeKey === submissionKey;
+
+    if (this.noteContextActive) {
+      const noteMsg = await buildNoteContextMessage(this.plugin.app);
+      if (noteMsg) {
+        this.applyNoteContext(core, noteMsg);
+      }
+      this.noteContextActive = false;
+      this.inputBar.setNoteActive(false);
+    }
+
+    // Guard: the user may have switched conversations during the async note build.
+    if (!isThisConvActive()) return;
+
+    this.messageRenderer.appendMessage('user', text);
+    this.inputBar.setLoading(true);
+    this.messageRenderer.beginAssistantMessage();
+
+    let hasStarted = false;
+    let hasUnlocked = false;
+    let unsubscribe: () => void;
+    unsubscribe = core.subscribe({
+      onDelta: (delta: string) => {
+        if (isThisConvActive()) this.messageRenderer.appendDelta(delta);
+      },
+      onStateChange: (state: { isSending: boolean; isStopping: boolean }) => {
+        // Track when streaming genuinely begins (not the initial idle emission).
+        if (state.isSending && !state.isStopping) { hasStarted = true; return; }
+        if (!hasStarted) return;
+
+        // Unlock the UI at the first sign that this response is ending.
+        // This matters most for LM Studio: requestUrl cannot be aborted, so after
+        // Stop is pressed isStopping goes true while isSending stays true until
+        // the HTTP round-trip finishes. Unlocking here gives immediate feedback.
+        if (!hasUnlocked && isThisConvActive()) {
+          hasUnlocked = true;
+          if (state.isStopping) {
+            this.messageRenderer.cancelAssistantMessage();
+          } else {
+            this.messageRenderer.finalizeAssistantMessage();
+          }
+          this.inputBar.setLoading(false);
+        }
+
+        // Unsubscribe once the stream is truly done.
+        if (!state.isSending) {
+          unsubscribe?.();
+        }
+      },
+    });
+
+    try {
+      await core.submitPrompt(text);
+    } catch (err) {
+      if (isThisConvActive() && !hasUnlocked) {
+        hasUnlocked = true;
+        this.messageRenderer.cancelAssistantMessage();
+        this.inputBar.setLoading(false);
+        const message = err instanceof Error ? err.message : String(err);
+        this.messageRenderer.showError(`Error: ${message}`);
+        new Notice(`Curraint: ${message}`);
+      }
+      unsubscribe?.();
+    }
+  }
+
+  private handleOpenSessions(): void {
+    new SessionsModal(this.app, (session) => this.handleLoadSession(session)).open();
+  }
+
+  private handleLoadSession(saved: SavedSession): void {
+    this.registry.loadSession(saved);
+    this.renderActiveSlot();
+    this.noteContextActive = false;
+    this.inputBar.setNoteActive(false);
+    this.inputBar.focus();
+  }
+
+  /**
+   * Sync the renderer and input bar to whichever conversation is active.
+   * If the slot is mid-stream, re-attach so future deltas flow into the view.
+   */
+  private renderActiveSlot(): void {
+    const slot = this.registry.getActiveSlot();
+    if (!slot) {
+      this.messageRenderer.renderAll([]);
+      this.inputBar.setLoading(false);
+      return;
+    }
+    const state = slot.core.getState();
+    if (state.isSending) {
+      const lastMsg = state.conversation[state.conversation.length - 1];
+      const isStreamingAssistant = lastMsg?.role === 'assistant';
+      const completeMsgs = isStreamingAssistant
+        ? state.conversation.slice(0, -1)
+        : state.conversation;
+      const partialContent = isStreamingAssistant ? lastMsg.content : '';
+      this.messageRenderer.renderAll(completeMsgs);
+      this.messageRenderer.beginAssistantMessage(partialContent);
+      this.inputBar.setLoading(true);
+    } else {
+      this.messageRenderer.renderAll(state.conversation);
+      this.inputBar.setLoading(false);
+    }
+  }
+
+  private applyNoteContext(core: ChatSessionCore, noteMsg: ChatMessage): void {
+    const { conversation } = core.getState();
+    const alreadyHasNoteContext =
+      conversation[0]?.role === 'system' &&
+      conversation[0]?.content.startsWith('The user has shared the following note');
+    const base = alreadyHasNoteContext ? conversation.slice(1) : conversation;
+    core.loadConversation([noteMsg, ...base]);
+  }
+}

--- a/packages/obsidian-plugin/src/chat/chat-view.ts
+++ b/packages/obsidian-plugin/src/chat/chat-view.ts
@@ -1,11 +1,13 @@
 import { ItemView, Notice, WorkspaceLeaf, setIcon } from 'obsidian';
+import type { TFile } from 'obsidian';
 import type CurraintPlugin from '../main';
 import { buildTransport } from '../transport';
-import { buildNoteContextMessage } from '../note-context';
+import { buildNoteContextMessageForFile } from '../note-context';
 import { ConversationRegistry } from './session-manager';
 import { MessageRenderer } from './message-renderer';
 import { InputBar } from './input-bar';
 import { SessionsModal } from './sessions-modal';
+import { NotePickerModal } from './note-picker-modal';
 import type { ChatMessage, ChatSessionCore, SavedSession } from '@curraint/core';
 
 export const CHAT_VIEW_TYPE = 'curraint-chat';
@@ -15,7 +17,8 @@ export class ChatView extends ItemView {
   private registry!: ConversationRegistry;
   private messageRenderer!: MessageRenderer;
   private inputBar!: InputBar;
-  private noteContextActive = false;
+  private pendingNoteFiles: TFile[] = [];
+  private headerTitle!: HTMLInputElement;
 
   constructor(leaf: WorkspaceLeaf, plugin: CurraintPlugin) {
     super(leaf);
@@ -40,42 +43,10 @@ export class ChatView extends ItemView {
 
     const header = document.createElement('div');
     header.className = 'curraint-chat-header';
+    header.appendChild(this.buildControls());
 
-    const formatToggle = document.createElement('button');
-    formatToggle.className = 'curraint-chat-header__format-toggle';
-    formatToggle.title = 'Switch to plain text';
-    formatToggle.setAttribute('aria-label', 'Switch to plain text');
-    setIcon(formatToggle, 'pilcrow');
-    formatToggle.addEventListener('click', () => {
-      const plain = !this.messageRenderer.isPlainMode;
-      this.messageRenderer.setPlainMode(plain);
-      if (plain) {
-        setIcon(formatToggle, 'code');
-        formatToggle.title = 'Switch to formatted view';
-        formatToggle.setAttribute('aria-label', 'Switch to formatted view');
-      } else {
-        setIcon(formatToggle, 'pilcrow');
-        formatToggle.title = 'Switch to plain text';
-        formatToggle.setAttribute('aria-label', 'Switch to plain text');
-      }
-    });
-    header.appendChild(formatToggle);
-
-    const newChatBtn = document.createElement('button');
-    newChatBtn.className = 'curraint-chat-header__new-chat';
-    newChatBtn.title = 'New conversation';
-    newChatBtn.setAttribute('aria-label', 'New conversation');
-    newChatBtn.textContent = 'Start a new conversation';
-    newChatBtn.addEventListener('click', () => this.handleNewConversation());
-    header.appendChild(newChatBtn);
-
-    const sessionsBtn = document.createElement('button');
-    sessionsBtn.className = 'curraint-chat-header__sessions';
-    sessionsBtn.title = 'Browse saved conversations';
-    sessionsBtn.setAttribute('aria-label', 'Browse saved conversations');
-    sessionsBtn.textContent = 'Conversations';
-    sessionsBtn.addEventListener('click', () => this.handleOpenSessions());
-    header.appendChild(sessionsBtn);
+    this.headerTitle = this.buildTitleInput();
+    header.appendChild(this.headerTitle);
     root.appendChild(header);
 
     const messagesEl = document.createElement('div');
@@ -94,9 +65,29 @@ export class ChatView extends ItemView {
 
     this.inputBar = new InputBar(inputEl, {
       onSubmit: (text) => { void this.handleSubmit(text); },
-      onNoteToggle: (active) => { void this.handleNoteToggle(active); },
+      onAddCurrentNote: () => { this.injectCurrentNote(); },
+      onNoteAdd: () => { this.handleOpenNotePicker(); },
+      onNoteRemove: (path) => { this.handleNoteRemove(path); },
       onStop: () => { this.registry.stopActive(); },
     });
+
+    // Keep the "+ <title>" button label in sync with the active note.
+    const syncNoteTitle = (): void => {
+      const file = this.plugin.app.workspace.getActiveFile();
+      this.inputBar.setCurrentNoteTitle(file?.basename ?? null);
+    };
+    syncNoteTitle();
+    this.registerEvent(
+      this.plugin.app.workspace.on('active-leaf-change', syncNoteTitle)
+    );
+    // Also update when the active note is renamed.
+    this.registerEvent(
+      this.plugin.app.vault.on('rename', (file) => {
+        if (file === this.plugin.app.workspace.getActiveFile()) {
+          syncNoteTitle();
+        }
+      })
+    );
 
     this.inputBar.focus();
   }
@@ -105,38 +96,43 @@ export class ChatView extends ItemView {
     this.registry.destroy();
   }
 
-  async injectCurrentNote(): Promise<void> {
+  injectCurrentNote(): void {
     const file = this.plugin.app.workspace.getActiveFile();
     if (!file) {
       new Notice('Curraint: No active note to add as context.');
       return;
     }
-    this.noteContextActive = true;
-    this.inputBar.setNoteActive(true, file.basename);
+    // Deduplicate: skip if this note is already in pending context.
+    if (this.pendingNoteFiles.some((f) => f.path === file.path)) return;
+    this.handleNotesConfirmed([...this.pendingNoteFiles, file]);
   }
 
   private handleNewConversation(): void {
     this.registry.newConversation();
     this.messageRenderer.renderAll([]);
     this.inputBar.setLoading(false);
-    this.noteContextActive = false;
-    this.inputBar.setNoteActive(false);
+    this.pendingNoteFiles = [];
+    this.inputBar.clearNoteChips();
+    this.updateHeaderTitle();
     this.inputBar.focus();
   }
 
-  private handleNoteToggle(active: boolean): void {
-    if (!active) {
-      this.noteContextActive = false;
-      return;
-    }
-    const file = this.plugin.app.workspace.getActiveFile();
-    if (!file) {
-      new Notice('Curraint: No active note to add as context.');
-      this.inputBar.setNoteActive(false);
-      return;
-    }
-    this.noteContextActive = true;
-    this.inputBar.setNoteActive(true, file.basename);
+  private handleOpenNotePicker(): void {
+    new NotePickerModal(
+      this.plugin.app,
+      this.inputBar.getSelectedPaths(),
+      (files) => { this.handleNotesConfirmed(files); }
+    ).open();
+  }
+
+  private handleNotesConfirmed(files: TFile[]): void {
+    this.pendingNoteFiles = files;
+    this.inputBar.setNoteChips(files);
+  }
+
+  private handleNoteRemove(path: string): void {
+    this.pendingNoteFiles = this.pendingNoteFiles.filter((f) => f.path !== path);
+    // The chip is already removed by InputBar; no need to call removeOneChip again.
   }
 
   private async handleSubmit(text: string): Promise<void> {
@@ -144,24 +140,30 @@ export class ChatView extends ItemView {
     const submissionKey = this.registry.activeKey;
     const isThisConvActive = (): boolean => this.registry.activeKey === submissionKey;
 
-    if (this.noteContextActive) {
-      const noteMsg = await buildNoteContextMessage(this.plugin.app);
-      if (noteMsg) {
-        this.applyNoteContext(core, noteMsg);
+    let filesToInject: TFile[] = [];
+    if (this.pendingNoteFiles.length > 0) {
+      filesToInject = this.pendingNoteFiles.slice();
+      this.pendingNoteFiles = [];
+      this.inputBar.clearNoteChips();
+      const noteMsgs = await Promise.all(
+        filesToInject.map((f) => buildNoteContextMessageForFile(this.plugin.app, f))
+      );
+      const valid = noteMsgs.filter((m): m is ChatMessage => m !== null);
+      if (valid.length > 0) {
+        this.applyNoteContextAll(core, valid);
       }
-      this.noteContextActive = false;
-      this.inputBar.setNoteActive(false);
     }
 
     // Guard: the user may have switched conversations during the async note build.
     if (!isThisConvActive()) return;
 
-    this.messageRenderer.appendMessage('user', text);
+    const noteNames = filesToInject.length > 0 ? filesToInject.map((f) => f.basename) : undefined;
+    this.messageRenderer.appendMessage('user', text, noteNames);
     this.inputBar.setLoading(true);
     this.messageRenderer.beginAssistantMessage();
 
     let hasStarted = false;
-    let hasUnlocked = false;
+    const unlock = this.createUnlockOnce(isThisConvActive);
     let unsubscribe: () => void;
     unsubscribe = core.subscribe({
       onDelta: (delta: string) => {
@@ -176,15 +178,7 @@ export class ChatView extends ItemView {
         // This matters most for LM Studio: requestUrl cannot be aborted, so after
         // Stop is pressed isStopping goes true while isSending stays true until
         // the HTTP round-trip finishes. Unlocking here gives immediate feedback.
-        if (!hasUnlocked && isThisConvActive()) {
-          hasUnlocked = true;
-          if (state.isStopping) {
-            this.messageRenderer.cancelAssistantMessage();
-          } else {
-            this.messageRenderer.finalizeAssistantMessage();
-          }
-          this.inputBar.setLoading(false);
-        }
+        unlock(state.isStopping);
 
         // Unsubscribe once the stream is truly done.
         if (!state.isSending) {
@@ -196,10 +190,8 @@ export class ChatView extends ItemView {
     try {
       await core.submitPrompt(text);
     } catch (err) {
-      if (isThisConvActive() && !hasUnlocked) {
-        hasUnlocked = true;
-        this.messageRenderer.cancelAssistantMessage();
-        this.inputBar.setLoading(false);
+      unlock(true);
+      if (isThisConvActive()) {
         const message = err instanceof Error ? err.message : String(err);
         this.messageRenderer.showError(`Error: ${message}`);
         new Notice(`Curraint: ${message}`);
@@ -215,8 +207,9 @@ export class ChatView extends ItemView {
   private handleLoadSession(saved: SavedSession): void {
     this.registry.loadSession(saved);
     this.renderActiveSlot();
-    this.noteContextActive = false;
-    this.inputBar.setNoteActive(false);
+    this.pendingNoteFiles = [];
+    this.inputBar.clearNoteChips();
+    this.updateHeaderTitle();
     this.inputBar.focus();
   }
 
@@ -248,12 +241,106 @@ export class ChatView extends ItemView {
     }
   }
 
-  private applyNoteContext(core: ChatSessionCore, noteMsg: ChatMessage): void {
+  private updateHeaderTitle(): void {
+    if (!this.headerTitle) return;
+    const slot = this.registry.getActiveSlot();
+    this.headerTitle.value = slot?.title ?? '';
+  }
+
+  // Returns the header controls row (format toggle, new chat, sessions buttons).
+  private buildControls(): HTMLElement {
+    const controls = document.createElement('div');
+    controls.className = 'curraint-chat-header__controls';
+
+    const formatToggle = document.createElement('button');
+    formatToggle.className = 'curraint-chat-header__format-toggle';
+    formatToggle.title = 'Switch to plain text';
+    formatToggle.setAttribute('aria-label', 'Switch to plain text');
+    setIcon(formatToggle, 'pilcrow');
+    formatToggle.addEventListener('click', () => {
+      const plain = !this.messageRenderer.isPlainMode;
+      this.messageRenderer.setPlainMode(plain);
+      if (plain) {
+        setIcon(formatToggle, 'code');
+        formatToggle.title = 'Switch to formatted view';
+        formatToggle.setAttribute('aria-label', 'Switch to formatted view');
+      } else {
+        setIcon(formatToggle, 'pilcrow');
+        formatToggle.title = 'Switch to plain text';
+        formatToggle.setAttribute('aria-label', 'Switch to plain text');
+      }
+    });
+    controls.appendChild(formatToggle);
+
+    const newChatBtn = document.createElement('button');
+    newChatBtn.className = 'curraint-chat-header__new-chat';
+    newChatBtn.title = 'New conversation';
+    newChatBtn.setAttribute('aria-label', 'New conversation');
+    newChatBtn.textContent = 'Start a new conversation';
+    newChatBtn.addEventListener('click', () => this.handleNewConversation());
+    controls.appendChild(newChatBtn);
+
+    const sessionsBtn = document.createElement('button');
+    sessionsBtn.className = 'curraint-chat-header__sessions';
+    sessionsBtn.title = 'Browse saved conversations';
+    sessionsBtn.setAttribute('aria-label', 'Browse saved conversations');
+    sessionsBtn.textContent = 'Conversations';
+    sessionsBtn.addEventListener('click', () => this.handleOpenSessions());
+    controls.appendChild(sessionsBtn);
+
+    return controls;
+  }
+
+  // Returns the editable title input for the active conversation.
+  private buildTitleInput(): HTMLInputElement {
+    const titleInput = document.createElement('input');
+    titleInput.type = 'text';
+    titleInput.className = 'curraint-chat-header__title';
+    titleInput.placeholder = 'New conversation';
+    titleInput.setAttribute('aria-label', 'Conversation title');
+    titleInput.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') { titleInput.blur(); }
+      if (e.key === 'Escape') {
+        this.updateHeaderTitle();
+        titleInput.blur();
+      }
+    });
+    titleInput.addEventListener('blur', () => {
+      this.registry.renameActive(titleInput.value);
+      this.updateHeaderTitle();
+    });
+    return titleInput;
+  }
+
+  // Returns a function that unlocks the UI exactly once, regardless of how
+  // many times it is called. When cancelled is true the streaming assistant
+  // bubble is discarded; otherwise it is finalized with rendered content.
+  private createUnlockOnce(isActive: () => boolean): (cancelled: boolean) => void {
+    let done = false;
+    return (cancelled: boolean): void => {
+      if (done || !isActive()) { done = true; return; }
+      done = true;
+      if (cancelled) {
+        this.messageRenderer.cancelAssistantMessage();
+      } else {
+        this.messageRenderer.finalizeAssistantMessage();
+      }
+      this.inputBar.setLoading(false);
+      this.updateHeaderTitle();
+    };
+  }
+
+  private applyNoteContextAll(core: ChatSessionCore, noteMsgs: ChatMessage[]): void {
     const { conversation } = core.getState();
-    const alreadyHasNoteContext =
-      conversation[0]?.role === 'system' &&
-      conversation[0]?.content.startsWith('The user has shared the following note');
-    const base = alreadyHasNoteContext ? conversation.slice(1) : conversation;
-    core.loadConversation([noteMsg, ...base]);
+    // Strip all leading note-context system messages inserted by previous sends.
+    let base = conversation;
+    while (
+      base.length > 0 &&
+      base[0].role === 'system' &&
+      base[0].content.startsWith('The user has shared the following note')
+    ) {
+      base = base.slice(1);
+    }
+    core.loadConversation([...noteMsgs, ...base]);
   }
 }

--- a/packages/obsidian-plugin/src/chat/chat-view.ts
+++ b/packages/obsidian-plugin/src/chat/chat-view.ts
@@ -38,8 +38,8 @@ export class ChatView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
-    const root = this.containerEl.children[1] as HTMLElement;
-    root.className = 'curraint-chat-view';
+    const root = this.resolveRootElement();
+    root.classList.add('curraint-chat-view');
 
     const header = document.createElement('div');
     header.className = 'curraint-chat-header';
@@ -93,6 +93,8 @@ export class ChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
+    this.inputBar?.destroy();
+    this.pendingNoteFiles = [];
     this.destroyRegistry();
   }
 
@@ -336,7 +338,8 @@ export class ChatView extends ItemView {
 
   private applyNoteContextAll(core: ChatSessionCore, noteMsgs: ChatMessage[]): void {
     const { conversation } = core.getState();
-    // Strip all leading note-context system messages inserted by previous sends.
+    // Replace only the current leading note context and preserve any later
+    // note-context injections that are part of the actual conversation history.
     let base = conversation;
     while (
       base.length > 0 &&
@@ -346,5 +349,24 @@ export class ChatView extends ItemView {
       base = base.slice(1);
     }
     core.loadConversation([...noteMsgs, ...base]);
+  }
+
+  private resolveRootElement(): HTMLElement {
+    const indexedRoot = this.containerEl.children.item(1);
+    if (indexedRoot instanceof HTMLElement) {
+      return indexedRoot;
+    }
+
+    const fallbackRoot = this.containerEl.querySelector('.view-content');
+    if (fallbackRoot instanceof HTMLElement) {
+      console.warn('Curraint: Chat view root fallback used because containerEl.children[1] was unavailable.');
+      return fallbackRoot;
+    }
+
+    const createdRoot = document.createElement('div');
+    createdRoot.className = 'view-content';
+    this.containerEl.appendChild(createdRoot);
+    console.warn('Curraint: Chat view root was missing; created a fallback view-content container.');
+    return createdRoot;
   }
 }

--- a/packages/obsidian-plugin/src/chat/chat-view.ts
+++ b/packages/obsidian-plugin/src/chat/chat-view.ts
@@ -2,7 +2,7 @@ import { ItemView, Notice, WorkspaceLeaf, setIcon } from 'obsidian';
 import type { TFile } from 'obsidian';
 import type CurraintPlugin from '../main';
 import { buildTransport } from '../transport';
-import { buildNoteContextMessageForFile } from '../note-context';
+import { buildNoteContextMessageForFile, NOTE_CONTEXT_PREFIX } from '../note-context';
 import { ConversationRegistry } from './session-manager';
 import { MessageRenderer } from './message-renderer';
 import { InputBar } from './input-bar';
@@ -64,7 +64,7 @@ export class ChatView extends ItemView {
     this.registry.init();
 
     this.inputBar = new InputBar(inputEl, {
-      onSubmit: (text) => { void this.handleSubmit(text); },
+      onSubmit: (text) => { this.handleSubmit(text).catch(() => {}); },
       onAddCurrentNote: () => { this.injectCurrentNote(); },
       onNoteAdd: () => { this.handleOpenNotePicker(); },
       onNoteRemove: (path) => { this.handleNoteRemove(path); },
@@ -337,7 +337,7 @@ export class ChatView extends ItemView {
     while (
       base.length > 0 &&
       base[0].role === 'system' &&
-      base[0].content.startsWith('The user has shared the following note')
+      base[0].content.startsWith(NOTE_CONTEXT_PREFIX)
     ) {
       base = base.slice(1);
     }

--- a/packages/obsidian-plugin/src/chat/delete-confirm-modal.ts
+++ b/packages/obsidian-plugin/src/chat/delete-confirm-modal.ts
@@ -1,0 +1,46 @@
+import { App, Modal } from 'obsidian';
+
+export class DeleteConfirmModal extends Modal {
+  private readonly title: string;
+  private readonly onConfirm: () => void;
+
+  constructor(app: App, title: string, onConfirm: () => void) {
+    super(app);
+    this.title = title;
+    this.onConfirm = onConfirm;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.addClass('curraint-delete-confirm-modal');
+
+    contentEl.createEl('p', {
+      text: `Delete "${this.title}"?`,
+      cls: 'curraint-delete-confirm-modal__message',
+    });
+
+    const actions = contentEl.createEl('div', { cls: 'curraint-delete-confirm-modal__actions' });
+
+    const cancelBtn = actions.createEl('button', {
+      text: 'Cancel',
+      cls: 'curraint-delete-confirm-modal__cancel',
+    });
+    cancelBtn.addEventListener('click', () => this.close());
+
+    const confirmBtn = actions.createEl('button', {
+      text: 'Delete',
+      cls: 'mod-warning curraint-delete-confirm-modal__confirm',
+    });
+    confirmBtn.addEventListener('click', () => {
+      this.onConfirm();
+      this.close();
+    });
+
+    // Focus cancel by default so Enter does not accidentally confirm.
+    cancelBtn.focus();
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/src/chat/input-bar.ts
+++ b/packages/obsidian-plugin/src/chat/input-bar.ts
@@ -1,0 +1,153 @@
+import { setIcon } from 'obsidian';
+
+export type InputBarCallbacks = {
+  onSubmit: (text: string) => void;
+  onNoteToggle: (active: boolean) => void;
+  onStop: () => void;
+};
+
+export class InputBar {
+  private readonly textarea: HTMLTextAreaElement;
+  private readonly sendButton: HTMLButtonElement;
+  private readonly stopButton: HTMLButtonElement;
+  private readonly noteAddButton: HTMLButtonElement;
+  private readonly contextBar: HTMLElement;
+  private readonly noteChip: HTMLElement;
+  private readonly noteChipLabel: HTMLSpanElement;
+  private _noteActive = false;
+
+  constructor(container: HTMLElement, callbacks: InputBarCallbacks) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'curraint-input-wrapper';
+
+    // Context bar - always visible; shows note-add button or note chip
+    this.contextBar = document.createElement('div');
+    this.contextBar.className = 'curraint-context-bar';
+
+    this.noteChip = document.createElement('span');
+    this.noteChip.className = 'curraint-note-chip';
+    this.noteChip.style.display = 'none';
+
+    const noteChipIcon = document.createElement('span');
+    noteChipIcon.className = 'curraint-note-chip__icon';
+    noteChipIcon.textContent = '\uD83D\uDCC4';
+
+    this.noteChipLabel = document.createElement('span');
+    this.noteChipLabel.className = 'curraint-note-chip__label';
+    this.noteChipLabel.textContent = 'Note';
+
+    const noteChipRemove = document.createElement('button');
+    noteChipRemove.className = 'curraint-note-chip__remove';
+    noteChipRemove.textContent = '\u00D7';
+    noteChipRemove.title = 'Remove note from context';
+    noteChipRemove.addEventListener('click', () => {
+      this.setNoteActive(false);
+      callbacks.onNoteToggle(false);
+    });
+
+    this.noteChip.appendChild(noteChipIcon);
+    this.noteChip.appendChild(this.noteChipLabel);
+    this.noteChip.appendChild(noteChipRemove);
+    this.contextBar.appendChild(this.noteChip);
+
+    // Main input row
+    const bar = document.createElement('div');
+    bar.className = 'curraint-input-bar';
+
+    this.textarea = document.createElement('textarea');
+    this.textarea.className = 'curraint-input-bar__textarea';
+    this.textarea.placeholder =
+      'Ask anything\u2026 (Enter to send, Shift+Enter for newline)';
+    this.textarea.rows = 1;
+    this.textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.trySubmit(callbacks.onSubmit);
+      }
+    });
+    this.textarea.addEventListener('input', () => this.autoResize());
+
+    this.noteAddButton = this.createButton(
+      'curraint-input-bar__note-add',
+      '+ Include note',
+      'Include current note as context'
+    );
+    this.noteAddButton.addEventListener('click', () => {
+      callbacks.onNoteToggle(true);
+    });
+    this.contextBar.appendChild(this.noteAddButton);
+
+    this.sendButton = this.createButton(
+      'curraint-input-bar__send',
+      '\u2191',
+      'Send message'
+    );
+    this.sendButton.addEventListener('click', () =>
+      this.trySubmit(callbacks.onSubmit)
+    );
+
+    this.stopButton = this.createButton(
+      'curraint-input-bar__stop',
+      '',
+      'Stop response'
+    );
+    setIcon(this.stopButton, 'square');
+    this.stopButton.style.display = 'none';
+    this.stopButton.addEventListener('click', () => callbacks.onStop());
+
+    bar.appendChild(this.textarea);
+    bar.appendChild(this.sendButton);
+    bar.appendChild(this.stopButton);
+
+    wrapper.appendChild(this.contextBar);
+    wrapper.appendChild(bar);
+    container.appendChild(wrapper);
+  }
+
+  setLoading(loading: boolean): void {
+    this.textarea.disabled = loading;
+    this.sendButton.style.display = loading ? 'none' : '';
+    this.stopButton.style.display = loading ? '' : 'none';
+  }
+
+  setNoteActive(active: boolean, noteName?: string): void {
+    this._noteActive = active;
+    if (noteName) this.noteChipLabel.textContent = noteName;
+    this.noteChip.style.display = active ? '' : 'none';
+    this.noteAddButton.style.display = active ? 'none' : '';
+    this.noteAddButton.setAttribute('aria-pressed', String(active));
+  }
+
+  get isNoteActive(): boolean {
+    return this._noteActive;
+  }
+
+  focus(): void {
+    this.textarea.focus();
+  }
+
+  private trySubmit(onSubmit: (text: string) => void): void {
+    const text = this.textarea.value.trim();
+    if (!text) return;
+    this.textarea.value = '';
+    this.autoResize();
+    onSubmit(text);
+  }
+
+  private autoResize(): void {
+    this.textarea.style.height = 'auto';
+    this.textarea.style.height = `${this.textarea.scrollHeight}px`;
+  }
+
+  private createButton(
+    cls: string,
+    text: string,
+    title: string
+  ): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.className = cls;
+    btn.textContent = text;
+    btn.title = title;
+    return btn;
+  }
+}

--- a/packages/obsidian-plugin/src/chat/input-bar.ts
+++ b/packages/obsidian-plugin/src/chat/input-bar.ts
@@ -1,8 +1,11 @@
 import { setIcon } from 'obsidian';
+import type { TFile } from 'obsidian';
 
 export type InputBarCallbacks = {
   onSubmit: (text: string) => void;
-  onNoteToggle: (active: boolean) => void;
+  onAddCurrentNote: () => void;
+  onNoteAdd: () => void;
+  onNoteRemove: (path: string) => void;
   onStop: () => void;
 };
 
@@ -10,45 +13,32 @@ export class InputBar {
   private readonly textarea: HTMLTextAreaElement;
   private readonly sendButton: HTMLButtonElement;
   private readonly stopButton: HTMLButtonElement;
+  private readonly addCurrentNoteButton: HTMLButtonElement;
   private readonly noteAddButton: HTMLButtonElement;
   private readonly contextBar: HTMLElement;
-  private readonly noteChip: HTMLElement;
-  private readonly noteChipLabel: HTMLSpanElement;
-  private _noteActive = false;
+  private readonly noteChipMap = new Map<string, HTMLElement>();
+  private callbacks: InputBarCallbacks;
 
   constructor(container: HTMLElement, callbacks: InputBarCallbacks) {
+    this.callbacks = callbacks;
+
     const wrapper = document.createElement('div');
     wrapper.className = 'curraint-input-wrapper';
 
-    // Context bar - always visible; shows note-add button or note chip
+    // Top bar - quick-add current note button (always leftmost) + chips
     this.contextBar = document.createElement('div');
     this.contextBar.className = 'curraint-context-bar';
 
-    this.noteChip = document.createElement('span');
-    this.noteChip.className = 'curraint-note-chip';
-    this.noteChip.style.display = 'none';
-
-    const noteChipIcon = document.createElement('span');
-    noteChipIcon.className = 'curraint-note-chip__icon';
-    noteChipIcon.textContent = '\uD83D\uDCC4';
-
-    this.noteChipLabel = document.createElement('span');
-    this.noteChipLabel.className = 'curraint-note-chip__label';
-    this.noteChipLabel.textContent = 'Note';
-
-    const noteChipRemove = document.createElement('button');
-    noteChipRemove.className = 'curraint-note-chip__remove';
-    noteChipRemove.textContent = '\u00D7';
-    noteChipRemove.title = 'Remove note from context';
-    noteChipRemove.addEventListener('click', () => {
-      this.setNoteActive(false);
-      callbacks.onNoteToggle(false);
+    this.addCurrentNoteButton = this.createButton(
+      'curraint-input-bar__add-current-note',
+      '+ Note',
+      'Add current note to context'
+    );
+    this.addCurrentNoteButton.addEventListener('click', () => {
+      callbacks.onAddCurrentNote();
     });
+    this.contextBar.appendChild(this.addCurrentNoteButton);
 
-    this.noteChip.appendChild(noteChipIcon);
-    this.noteChip.appendChild(this.noteChipLabel);
-    this.noteChip.appendChild(noteChipRemove);
-    this.contextBar.appendChild(this.noteChip);
 
     // Main input row
     const bar = document.createElement('div');
@@ -66,16 +56,6 @@ export class InputBar {
       }
     });
     this.textarea.addEventListener('input', () => this.autoResize());
-
-    this.noteAddButton = this.createButton(
-      'curraint-input-bar__note-add',
-      '+ Include note',
-      'Include current note as context'
-    );
-    this.noteAddButton.addEventListener('click', () => {
-      callbacks.onNoteToggle(true);
-    });
-    this.contextBar.appendChild(this.noteAddButton);
 
     this.sendButton = this.createButton(
       'curraint-input-bar__send',
@@ -99,31 +79,110 @@ export class InputBar {
     bar.appendChild(this.sendButton);
     bar.appendChild(this.stopButton);
 
+    // Bottom bar - browse-and-add-notes button
+    const bottomBar = document.createElement('div');
+    bottomBar.className = 'curraint-input-bottom-bar';
+
+    this.noteAddButton = this.createButton(
+      'curraint-input-bar__note-add',
+      '+ Add notes',
+      'Browse and add notes to context'
+    );
+    this.noteAddButton.addEventListener('click', () => {
+      callbacks.onNoteAdd();
+    });
+    bottomBar.appendChild(this.noteAddButton);
+
     wrapper.appendChild(this.contextBar);
     wrapper.appendChild(bar);
+    wrapper.appendChild(bottomBar);
     container.appendChild(wrapper);
+  }
+
+  /** Update the label on the quick-add button to reflect the active note title. */
+  setCurrentNoteTitle(title: string | null): void {
+    this.addCurrentNoteButton.textContent = title ? `+ ${title}` : '+ Note';
+    this.addCurrentNoteButton.title = title
+      ? `Add "${title}" to context`
+      : 'Add current note to context';
   }
 
   setLoading(loading: boolean): void {
     this.textarea.disabled = loading;
+    this.addCurrentNoteButton.disabled = loading;
+    this.noteAddButton.disabled = loading;
     this.sendButton.style.display = loading ? 'none' : '';
     this.stopButton.style.display = loading ? '' : 'none';
   }
 
-  setNoteActive(active: boolean, noteName?: string): void {
-    this._noteActive = active;
-    if (noteName) this.noteChipLabel.textContent = noteName;
-    this.noteChip.style.display = active ? '' : 'none';
-    this.noteAddButton.style.display = active ? 'none' : '';
-    this.noteAddButton.setAttribute('aria-pressed', String(active));
+  /** Replace the full set of note chips with the given files. */
+  setNoteChips(files: TFile[]): void {
+    // Remove chips that are no longer in the list.
+    for (const [path, el] of this.noteChipMap) {
+      if (!files.some((f) => f.path === path)) {
+        el.remove();
+        this.noteChipMap.delete(path);
+      }
+    }
+    // Add chips for newly selected files (preserve existing ones).
+    for (const file of files) {
+      if (!this.noteChipMap.has(file.path)) {
+        const chip = this.createChip(file);
+        this.contextBar.appendChild(chip);
+        this.noteChipMap.set(file.path, chip);
+      }
+    }
   }
 
-  get isNoteActive(): boolean {
-    return this._noteActive;
+  /** Remove a single chip by file path. */
+  removeOneChip(path: string): void {
+    const el = this.noteChipMap.get(path);
+    if (el) {
+      el.remove();
+      this.noteChipMap.delete(path);
+    }
+  }
+
+  /** Remove all chips (e.g. after a message is sent). */
+  clearNoteChips(): void {
+    for (const el of this.noteChipMap.values()) el.remove();
+    this.noteChipMap.clear();
+  }
+
+  /** Returns paths of all currently displayed chips. */
+  getSelectedPaths(): string[] {
+    return Array.from(this.noteChipMap.keys());
   }
 
   focus(): void {
     this.textarea.focus();
+  }
+
+  private createChip(file: TFile): HTMLElement {
+    const chip = document.createElement('span');
+    chip.className = 'curraint-note-chip';
+
+    const icon = document.createElement('span');
+    icon.className = 'curraint-note-chip__icon';
+    icon.textContent = '\uD83D\uDCC4';
+
+    const label = document.createElement('span');
+    label.className = 'curraint-note-chip__label';
+    label.textContent = file.basename;
+
+    const remove = document.createElement('button');
+    remove.className = 'curraint-note-chip__remove';
+    remove.textContent = '\u00D7';
+    remove.title = 'Remove note from context';
+    remove.addEventListener('click', () => {
+      this.removeOneChip(file.path);
+      this.callbacks.onNoteRemove(file.path);
+    });
+
+    chip.appendChild(icon);
+    chip.appendChild(label);
+    chip.appendChild(remove);
+    return chip;
   }
 
   private trySubmit(onSubmit: (text: string) => void): void {
@@ -151,3 +210,4 @@ export class InputBar {
     return btn;
   }
 }
+

--- a/packages/obsidian-plugin/src/chat/input-bar.ts
+++ b/packages/obsidian-plugin/src/chat/input-bar.ts
@@ -9,21 +9,58 @@ export type InputBarCallbacks = {
   onStop: () => void;
 };
 
+type NoteChipEntry = {
+  element: HTMLElement;
+  removeButton: HTMLButtonElement;
+  removeHandler: () => void;
+};
+
+const NOOP_CALLBACKS: InputBarCallbacks = {
+  onSubmit: () => {},
+  onAddCurrentNote: () => {},
+  onNoteAdd: () => {},
+  onNoteRemove: () => {},
+  onStop: () => {},
+};
+
 export class InputBar {
-  private readonly textarea: HTMLTextAreaElement;
-  private readonly sendButton: HTMLButtonElement;
-  private readonly stopButton: HTMLButtonElement;
-  private readonly addCurrentNoteButton: HTMLButtonElement;
-  private readonly noteAddButton: HTMLButtonElement;
-  private readonly contextBar: HTMLElement;
-  private readonly noteChipMap = new Map<string, HTMLElement>();
+  private wrapper: HTMLElement | null;
+  private textarea: HTMLTextAreaElement | null;
+  private sendButton: HTMLButtonElement | null;
+  private stopButton: HTMLButtonElement | null;
+  private addCurrentNoteButton: HTMLButtonElement | null;
+  private noteAddButton: HTMLButtonElement | null;
+  private contextBar: HTMLElement | null;
+  private readonly noteChipMap = new Map<string, NoteChipEntry>();
   private callbacks: InputBarCallbacks;
+  private readonly handleTextareaKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.trySubmit();
+    }
+  };
+  private readonly handleTextareaInput = (): void => {
+    this.autoResize();
+  };
+  private readonly handleSendClick = (): void => {
+    this.trySubmit();
+  };
+  private readonly handleStopClick = (): void => {
+    this.callbacks.onStop();
+  };
+  private readonly handleAddCurrentNoteClick = (): void => {
+    this.callbacks.onAddCurrentNote();
+  };
+  private readonly handleNoteAddClick = (): void => {
+    this.callbacks.onNoteAdd();
+  };
 
   constructor(container: HTMLElement, callbacks: InputBarCallbacks) {
     this.callbacks = callbacks;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'curraint-input-wrapper';
+    this.wrapper = wrapper;
 
     // Top bar - quick-add current note button (always leftmost) + chips
     this.contextBar = document.createElement('div');
@@ -34,9 +71,7 @@ export class InputBar {
       '+ Note',
       'Add current note to context'
     );
-    this.addCurrentNoteButton.addEventListener('click', () => {
-      callbacks.onAddCurrentNote();
-    });
+    this.addCurrentNoteButton.addEventListener('click', this.handleAddCurrentNoteClick);
     this.contextBar.appendChild(this.addCurrentNoteButton);
 
 
@@ -49,22 +84,15 @@ export class InputBar {
     this.textarea.placeholder =
       'Ask anything\u2026 (Enter to send, Shift+Enter for newline)';
     this.textarea.rows = 1;
-    this.textarea.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        this.trySubmit(callbacks.onSubmit);
-      }
-    });
-    this.textarea.addEventListener('input', () => this.autoResize());
+    this.textarea.addEventListener('keydown', this.handleTextareaKeydown);
+    this.textarea.addEventListener('input', this.handleTextareaInput);
 
     this.sendButton = this.createButton(
       'curraint-input-bar__send',
       '\u2191',
       'Send message'
     );
-    this.sendButton.addEventListener('click', () =>
-      this.trySubmit(callbacks.onSubmit)
-    );
+    this.sendButton.addEventListener('click', this.handleSendClick);
 
     this.stopButton = this.createButton(
       'curraint-input-bar__stop',
@@ -73,7 +101,7 @@ export class InputBar {
     );
     setIcon(this.stopButton, 'square');
     this.stopButton.style.display = 'none';
-    this.stopButton.addEventListener('click', () => callbacks.onStop());
+    this.stopButton.addEventListener('click', this.handleStopClick);
 
     bar.appendChild(this.textarea);
     bar.appendChild(this.sendButton);
@@ -88,9 +116,7 @@ export class InputBar {
       '+ Add notes',
       'Browse and add notes to context'
     );
-    this.noteAddButton.addEventListener('click', () => {
-      callbacks.onNoteAdd();
-    });
+    this.noteAddButton.addEventListener('click', this.handleNoteAddClick);
     bottomBar.appendChild(this.noteAddButton);
 
     wrapper.appendChild(this.contextBar);
@@ -101,6 +127,8 @@ export class InputBar {
 
   /** Update the label on the quick-add button to reflect the active note title. */
   setCurrentNoteTitle(title: string | null): void {
+    if (!this.addCurrentNoteButton) return;
+
     this.addCurrentNoteButton.textContent = title ? `+ ${title}` : '+ Note';
     this.addCurrentNoteButton.title = title
       ? `Add "${title}" to context`
@@ -108,6 +136,16 @@ export class InputBar {
   }
 
   setLoading(loading: boolean): void {
+    if (
+      !this.textarea ||
+      !this.addCurrentNoteButton ||
+      !this.noteAddButton ||
+      !this.sendButton ||
+      !this.stopButton
+    ) {
+      return;
+    }
+
     this.textarea.disabled = loading;
     this.addCurrentNoteButton.disabled = loading;
     this.noteAddButton.disabled = loading;
@@ -117,18 +155,20 @@ export class InputBar {
 
   /** Replace the full set of note chips with the given files. */
   setNoteChips(files: TFile[]): void {
+    if (!this.contextBar) return;
+
     // Remove chips that are no longer in the list.
-    for (const [path, el] of this.noteChipMap) {
+    for (const [path] of this.noteChipMap) {
       if (!files.some((f) => f.path === path)) {
-        el.remove();
-        this.noteChipMap.delete(path);
+        this.removeOneChip(path);
       }
     }
+
     // Add chips for newly selected files (preserve existing ones).
     for (const file of files) {
       if (!this.noteChipMap.has(file.path)) {
         const chip = this.createChip(file);
-        this.contextBar.appendChild(chip);
+        this.contextBar.appendChild(chip.element);
         this.noteChipMap.set(file.path, chip);
       }
     }
@@ -136,16 +176,19 @@ export class InputBar {
 
   /** Remove a single chip by file path. */
   removeOneChip(path: string): void {
-    const el = this.noteChipMap.get(path);
-    if (el) {
-      el.remove();
+    const chip = this.noteChipMap.get(path);
+    if (chip) {
+      chip.removeButton.removeEventListener('click', chip.removeHandler);
+      chip.element.remove();
       this.noteChipMap.delete(path);
     }
   }
 
   /** Remove all chips (e.g. after a message is sent). */
   clearNoteChips(): void {
-    for (const el of this.noteChipMap.values()) el.remove();
+    for (const path of [...this.noteChipMap.keys()]) {
+      this.removeOneChip(path);
+    }
     this.noteChipMap.clear();
   }
 
@@ -155,10 +198,33 @@ export class InputBar {
   }
 
   focus(): void {
-    this.textarea.focus();
+    this.textarea?.focus();
   }
 
-  private createChip(file: TFile): HTMLElement {
+  destroy(): void {
+    if (!this.wrapper) return;
+
+    this.textarea?.removeEventListener('keydown', this.handleTextareaKeydown);
+    this.textarea?.removeEventListener('input', this.handleTextareaInput);
+    this.sendButton?.removeEventListener('click', this.handleSendClick);
+    this.stopButton?.removeEventListener('click', this.handleStopClick);
+    this.addCurrentNoteButton?.removeEventListener('click', this.handleAddCurrentNoteClick);
+    this.noteAddButton?.removeEventListener('click', this.handleNoteAddClick);
+
+    this.clearNoteChips();
+    this.contextBar?.replaceChildren();
+    this.wrapper.remove();
+    this.callbacks = NOOP_CALLBACKS;
+    this.textarea = null;
+    this.sendButton = null;
+    this.stopButton = null;
+    this.addCurrentNoteButton = null;
+    this.noteAddButton = null;
+    this.contextBar = null;
+    this.wrapper = null;
+  }
+
+  private createChip(file: TFile): NoteChipEntry {
     const chip = document.createElement('span');
     chip.className = 'curraint-note-chip';
 
@@ -174,26 +240,31 @@ export class InputBar {
     remove.className = 'curraint-note-chip__remove';
     remove.textContent = '\u00D7';
     remove.title = 'Remove note from context';
-    remove.addEventListener('click', () => {
+    const removeHandler = (): void => {
       this.removeOneChip(file.path);
       this.callbacks.onNoteRemove(file.path);
-    });
+    };
+    remove.addEventListener('click', removeHandler);
 
     chip.appendChild(icon);
     chip.appendChild(label);
     chip.appendChild(remove);
-    return chip;
+    return { element: chip, removeButton: remove, removeHandler };
   }
 
-  private trySubmit(onSubmit: (text: string) => void): void {
+  private trySubmit(): void {
+    if (!this.textarea) return;
+
     const text = this.textarea.value.trim();
     if (!text) return;
     this.textarea.value = '';
     this.autoResize();
-    onSubmit(text);
+    this.callbacks.onSubmit(text);
   }
 
   private autoResize(): void {
+    if (!this.textarea) return;
+
     this.textarea.style.height = 'auto';
     this.textarea.style.height = `${this.textarea.scrollHeight}px`;
   }

--- a/packages/obsidian-plugin/src/chat/message-renderer.test.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.test.ts
@@ -156,5 +156,19 @@ describe('MessageRenderer', () => {
       renderer.setPlainMode(false);
       expect(container.children.length).toBe(initialCount);
     });
+
+    it('keeps streaming deltas attached to the visible bubble when plain mode changes mid-stream', async () => {
+      renderer.beginAssistantMessage();
+      renderer.appendDelta('Hello');
+
+      renderer.setPlainMode(true);
+      renderer.appendDelta(' world');
+      renderer.finalizeAssistantMessage();
+      await Promise.resolve();
+
+      const el = container.querySelector('.curraint-message__content');
+      expect(el?.textContent).toBe('Hello world');
+      expect(container.querySelector('.curraint-message--streaming')).toBeNull();
+    });
   });
 });

--- a/packages/obsidian-plugin/src/chat/message-renderer.test.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MessageRenderer } from './message-renderer';
+import type { App, Component } from 'obsidian';
+
+vi.mock('obsidian', () => ({
+  MarkdownRenderer: {
+    render: vi.fn(async (_app: unknown, markdown: string, el: HTMLElement) => {
+      el.textContent = markdown;
+    }),
+  },
+}));
+
+describe('MessageRenderer', () => {
+  let container: HTMLDivElement;
+  let renderer: MessageRenderer;
+  const mockApp = {} as App;
+  const mockComponent = {} as Component;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    renderer = new MessageRenderer(container, mockApp, mockComponent);
+  });
+
+  it('renders user and assistant messages, skipping system ones', () => {
+    renderer.renderAll([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+    ]);
+    const messages = container.querySelectorAll('.curraint-message');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].classList.contains('curraint-message--user')).toBe(true);
+    expect(messages[1].classList.contains('curraint-message--assistant')).toBe(true);
+  });
+
+  it('clears previous content on renderAll', () => {
+    renderer.appendMessage('user', 'Old');
+    renderer.renderAll([{ role: 'user', content: 'New' }]);
+    expect(container.querySelectorAll('.curraint-message')).toHaveLength(1);
+    expect(container.querySelector('.curraint-message__content')?.textContent).toBe('New');
+  });
+
+  it('appends delta text to the active streaming message', () => {
+    renderer.beginAssistantMessage();
+    renderer.appendDelta('Hello');
+    renderer.appendDelta(' world');
+    expect(container.querySelector('.curraint-message__content')?.textContent).toBe('Hello world');
+  });
+
+  it('finalizeAssistantMessage removes the streaming class', () => {
+    renderer.beginAssistantMessage();
+    renderer.appendDelta('Done');
+    renderer.finalizeAssistantMessage();
+    expect(container.querySelector('.curraint-message--streaming')).toBeNull();
+  });
+
+  it('appendDelta is a no-op when no streaming message is active', () => {
+    expect(() => renderer.appendDelta('text')).not.toThrow();
+  });
+
+  it('showError adds an error element with the message text', () => {
+    renderer.showError('Something went wrong');
+    const el = container.querySelector('.curraint-message--error');
+    expect(el?.textContent).toBe('Something went wrong');
+  });
+
+  describe('cancelAssistantMessage', () => {
+    it('removes the streaming bubble when no content has been received', () => {
+      renderer.beginAssistantMessage();
+      expect(container.querySelector('.curraint-message--streaming')).not.toBeNull();
+
+      renderer.cancelAssistantMessage();
+
+      expect(container.querySelector('.curraint-message')).toBeNull();
+    });
+
+    it('is a no-op when there is no active streaming message', () => {
+      expect(() => renderer.cancelAssistantMessage()).not.toThrow();
+      expect(container.querySelectorAll('.curraint-message')).toHaveLength(0);
+    });
+
+    it('finalizes instead of removing when partial content was streamed', () => {
+      renderer.beginAssistantMessage();
+      renderer.appendDelta('Partial response');
+
+      renderer.cancelAssistantMessage();
+
+      const msg = container.querySelector('.curraint-message');
+      expect(msg).not.toBeNull();
+      expect(msg?.classList.contains('curraint-message--streaming')).toBe(false);
+      expect(container.querySelector('.curraint-message__content')?.textContent).toBe('Partial response');
+    });
+
+    it('does not add an empty assistant entry to storedMessages when cancelling with no content', () => {
+      renderer.appendMessage('user', 'Hello');
+      renderer.beginAssistantMessage();
+      renderer.cancelAssistantMessage();
+
+      // Re-render - should only show the user message.
+      renderer.setPlainMode(false);
+      const messages = container.querySelectorAll('.curraint-message');
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.classList.contains('curraint-message--user')).toBe(true);
+    });
+  });
+
+  describe('plain mode', () => {
+    it('isPlainMode is false by default', () => {
+      expect(renderer.isPlainMode).toBe(false);
+    });
+
+    it('in plain mode, assistant messages use textContent instead of MarkdownRenderer', async () => {
+      renderer.setPlainMode(true);
+      renderer.appendMessage('assistant', '**bold**');
+      // Wait for any pending microtasks
+      await Promise.resolve();
+      const el = container.querySelector('.curraint-message__content');
+      expect(el?.textContent).toBe('**bold**');
+    });
+
+    it('in plain mode, finalizeAssistantMessage uses textContent', async () => {
+      renderer.setPlainMode(true);
+      renderer.beginAssistantMessage();
+      renderer.appendDelta('# Heading');
+      renderer.finalizeAssistantMessage();
+      await Promise.resolve();
+      const el = container.querySelector('.curraint-message__content');
+      expect(el?.textContent).toBe('# Heading');
+    });
+
+    it('toggling to plain mode re-renders existing messages as plain text', async () => {
+      renderer.appendMessage('assistant', '**bold**');
+      await Promise.resolve();
+      renderer.setPlainMode(true);
+      await Promise.resolve();
+      const el = container.querySelector('.curraint-message__content');
+      expect(el?.textContent).toBe('**bold**');
+    });
+
+    it('toggling back to rendered mode re-renders using MarkdownRenderer', async () => {
+      const { MarkdownRenderer } = await import('obsidian');
+      const renderSpy = vi.mocked(MarkdownRenderer.render);
+      renderSpy.mockClear();
+
+      renderer.setPlainMode(true);
+      renderer.appendMessage('assistant', '**bold**');
+      renderer.setPlainMode(false);
+      await Promise.resolve();
+
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it('setPlainMode is a no-op when called with the current value', () => {
+      const initialCount = container.children.length;
+      renderer.setPlainMode(false);
+      expect(container.children.length).toBe(initialCount);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/chat/message-renderer.test.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.test.ts
@@ -157,6 +157,26 @@ describe('MessageRenderer', () => {
       expect(container.children.length).toBe(initialCount);
     });
 
+    it('keeps raw text visible and shows a warning when markdown rendering fails', async () => {
+      const { MarkdownRenderer } = await import('obsidian');
+      const renderSpy = vi.mocked(MarkdownRenderer.render);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      renderSpy.mockRejectedValueOnce(new Error('boom'));
+
+      renderer.appendMessage('assistant', '**bold**');
+      await Promise.resolve();
+
+      const el = container.querySelector('.curraint-message__content') as HTMLElement | null;
+      const warning = container.querySelector('.curraint-message__render-warning') as HTMLElement | null;
+
+      expect(el?.dataset.markdownRenderFailed).toBe('true');
+      expect(el?.textContent).toContain('**bold**');
+      expect(warning?.textContent).toBe('Failed to render markdown');
+      expect(warning?.title).toBe('boom');
+
+      errorSpy.mockRestore();
+    });
+
     it('keeps streaming deltas attached to the visible bubble when plain mode changes mid-stream', async () => {
       renderer.beginAssistantMessage();
       renderer.appendDelta('Hello');

--- a/packages/obsidian-plugin/src/chat/message-renderer.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.ts
@@ -79,7 +79,7 @@ export class MessageRenderer {
       el.textContent = raw;
     } else {
       el.textContent = '';
-      void MarkdownRenderer.render(this.app, raw, el, '', this.component);
+      this.renderMarkdown(raw, el);
     }
     this.activeContentEl = null;
     this.activeRawContent = '';
@@ -115,7 +115,7 @@ export class MessageRenderer {
     const contentEl = document.createElement('div');
     contentEl.className = 'curraint-message__content';
     if (role === 'assistant' && !this.plainMode) {
-      void MarkdownRenderer.render(this.app, content, contentEl, '', this.component);
+      this.renderMarkdown(content, contentEl);
     } else {
       contentEl.textContent = content;
     }
@@ -147,5 +147,11 @@ export class MessageRenderer {
 
   private scrollToBottom(): void {
     this.container.scrollTop = this.container.scrollHeight;
+  }
+
+  private renderMarkdown(raw: string, el: HTMLElement): void {
+    MarkdownRenderer.render(this.app, raw, el, '', this.component).catch((error: unknown) => {
+      console.error('Curraint: Failed to render markdown.', error);
+    });
   }
 }

--- a/packages/obsidian-plugin/src/chat/message-renderer.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.ts
@@ -1,7 +1,7 @@
 import { App, Component, MarkdownRenderer } from 'obsidian';
 import type { ChatMessage } from '@curraint/core';
 
-type StoredMessage = { role: ChatMessage['role']; content: string };
+type StoredMessage = { role: ChatMessage['role']; content: string; noteNames?: string[] };
 
 export class MessageRenderer {
   private readonly container: HTMLElement;
@@ -40,9 +40,9 @@ export class MessageRenderer {
     }
   }
 
-  appendMessage(role: ChatMessage['role'], content: string): HTMLElement {
-    this.storedMessages.push({ role, content });
-    return this.renderMessage(role, content);
+  appendMessage(role: ChatMessage['role'], content: string, noteNames?: string[]): HTMLElement {
+    this.storedMessages.push({ role, content, noteNames });
+    return this.renderMessage(role, content, noteNames);
   }
 
   beginAssistantMessage(initialContent = ''): void {
@@ -109,7 +109,7 @@ export class MessageRenderer {
     this.scrollToBottom();
   }
 
-  private renderMessage(role: ChatMessage['role'], content: string): HTMLElement {
+  private renderMessage(role: ChatMessage['role'], content: string, noteNames?: string[]): HTMLElement {
     const wrapper = document.createElement('div');
     wrapper.className = `curraint-message curraint-message--${role}`;
     const contentEl = document.createElement('div');
@@ -120,6 +120,17 @@ export class MessageRenderer {
       contentEl.textContent = content;
     }
     wrapper.appendChild(contentEl);
+    if (role === 'user' && noteNames && noteNames.length > 0) {
+      const tagsEl = document.createElement('div');
+      tagsEl.className = 'curraint-message__note-tags';
+      for (const name of noteNames) {
+        const tag = document.createElement('span');
+        tag.className = 'curraint-message__note-tag';
+        tag.textContent = name;
+        tagsEl.appendChild(tag);
+      }
+      wrapper.appendChild(tagsEl);
+    }
     this.container.appendChild(wrapper);
     this.scrollToBottom();
     return wrapper;
@@ -130,7 +141,7 @@ export class MessageRenderer {
     this.container.innerHTML = '';
     this.storedMessages = [];
     for (const msg of stored) {
-      this.appendMessage(msg.role, msg.content);
+      this.appendMessage(msg.role, msg.content, msg.noteNames);
     }
   }
 

--- a/packages/obsidian-plugin/src/chat/message-renderer.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.ts
@@ -157,6 +157,16 @@ export class MessageRenderer {
   private renderMarkdown(raw: string, el: HTMLElement): void {
     MarkdownRenderer.render(this.app, raw, el, '', this.component).catch((error: unknown) => {
       console.error('Curraint: Failed to render markdown.', error);
+      el.dataset.markdownRenderFailed = 'true';
+      el.textContent = raw;
+
+      const warning = document.createElement('div');
+      warning.className = 'curraint-message__render-warning';
+      warning.textContent = 'Failed to render markdown';
+      warning.title = error instanceof Error ? error.message : String(error);
+      warning.setAttribute('role', 'status');
+      warning.setAttribute('aria-label', `Failed to render markdown: ${warning.title}`);
+      el.appendChild(warning);
     });
   }
 }

--- a/packages/obsidian-plugin/src/chat/message-renderer.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.ts
@@ -1,0 +1,140 @@
+import { App, Component, MarkdownRenderer } from 'obsidian';
+import type { ChatMessage } from '@curraint/core';
+
+type StoredMessage = { role: ChatMessage['role']; content: string };
+
+export class MessageRenderer {
+  private readonly container: HTMLElement;
+  private readonly app: App;
+  private readonly component: Component;
+  private activeContentEl: HTMLElement | null = null;
+  private activeRawContent = '';
+  private plainMode = false;
+  private storedMessages: StoredMessage[] = [];
+
+  constructor(container: HTMLElement, app: App, component: Component) {
+    this.container = container;
+    this.app = app;
+    this.component = component;
+  }
+
+  get isPlainMode(): boolean {
+    return this.plainMode;
+  }
+
+  setPlainMode(plain: boolean): void {
+    if (this.plainMode === plain) return;
+    this.plainMode = plain;
+    this.rerender();
+  }
+
+  renderAll(messages: ChatMessage[]): void {
+    this.storedMessages = [];
+    this.container.innerHTML = '';
+    this.activeContentEl = null;
+    this.activeRawContent = '';
+    for (const msg of messages) {
+      if (msg.role !== 'system') {
+        this.appendMessage(msg.role, msg.content);
+      }
+    }
+  }
+
+  appendMessage(role: ChatMessage['role'], content: string): HTMLElement {
+    this.storedMessages.push({ role, content });
+    return this.renderMessage(role, content);
+  }
+
+  beginAssistantMessage(initialContent = ''): void {
+    const wrapper = document.createElement('div');
+    wrapper.className =
+      'curraint-message curraint-message--assistant curraint-message--streaming';
+    const contentEl = document.createElement('div');
+    contentEl.className = 'curraint-message__content';
+    wrapper.appendChild(contentEl);
+    this.container.appendChild(wrapper);
+    this.activeContentEl = contentEl;
+    this.activeRawContent = initialContent;
+    if (initialContent) {
+      contentEl.textContent = initialContent;
+    }
+    this.scrollToBottom();
+  }
+
+  appendDelta(delta: string): void {
+    if (!this.activeContentEl) return;
+    this.activeRawContent += delta;
+    this.activeContentEl.textContent = this.activeRawContent;
+    this.scrollToBottom();
+  }
+
+  finalizeAssistantMessage(): void {
+    if (!this.activeContentEl) return;
+    const el = this.activeContentEl;
+    const raw = this.activeRawContent;
+    el.closest('.curraint-message--streaming')
+      ?.classList.remove('curraint-message--streaming');
+    this.storedMessages.push({ role: 'assistant', content: raw });
+    if (this.plainMode) {
+      el.textContent = raw;
+    } else {
+      el.textContent = '';
+      void MarkdownRenderer.render(this.app, raw, el, '', this.component);
+    }
+    this.activeContentEl = null;
+    this.activeRawContent = '';
+  }
+
+  /**
+   * Called when Stop is pressed. If partial content was already streamed,
+   * finalize it so it stays visible. If nothing was received yet (e.g. LM
+   * Studio which does not stream), remove the empty bubble entirely.
+   */
+  cancelAssistantMessage(): void {
+    if (!this.activeContentEl) return;
+    if (this.activeRawContent.trim()) {
+      this.finalizeAssistantMessage();
+      return;
+    }
+    this.activeContentEl.closest('.curraint-message')?.remove();
+    this.activeContentEl = null;
+    this.activeRawContent = '';
+  }
+
+  showError(message: string): void {
+    const el = document.createElement('div');
+    el.className = 'curraint-message curraint-message--error';
+    el.textContent = message;
+    this.container.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  private renderMessage(role: ChatMessage['role'], content: string): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = `curraint-message curraint-message--${role}`;
+    const contentEl = document.createElement('div');
+    contentEl.className = 'curraint-message__content';
+    if (role === 'assistant' && !this.plainMode) {
+      void MarkdownRenderer.render(this.app, content, contentEl, '', this.component);
+    } else {
+      contentEl.textContent = content;
+    }
+    wrapper.appendChild(contentEl);
+    this.container.appendChild(wrapper);
+    this.scrollToBottom();
+    return wrapper;
+  }
+
+  private rerender(): void {
+    const stored = this.storedMessages.slice();
+    this.container.innerHTML = '';
+    this.storedMessages = [];
+    for (const msg of stored) {
+      this.appendMessage(msg.role, msg.content);
+    }
+  }
+
+  private scrollToBottom(): void {
+    this.container.scrollTop = this.container.scrollHeight;
+  }
+}

--- a/packages/obsidian-plugin/src/chat/message-renderer.ts
+++ b/packages/obsidian-plugin/src/chat/message-renderer.ts
@@ -138,10 +138,15 @@ export class MessageRenderer {
 
   private rerender(): void {
     const stored = this.storedMessages.slice();
+    const activeRaw = this.activeContentEl ? this.activeRawContent : null;
     this.container.innerHTML = '';
+    this.activeContentEl = null;
     this.storedMessages = [];
     for (const msg of stored) {
       this.appendMessage(msg.role, msg.content, msg.noteNames);
+    }
+    if (activeRaw !== null) {
+      this.beginAssistantMessage(activeRaw);
     }
   }
 

--- a/packages/obsidian-plugin/src/chat/note-picker-modal.ts
+++ b/packages/obsidian-plugin/src/chat/note-picker-modal.ts
@@ -7,9 +7,12 @@ export class NotePickerModal extends Modal {
   private readonly onConfirm: (files: TFile[]) => void;
   private checked: Set<string>;
   private allFiles: TFile[] = [];
-  private listEl!: HTMLElement;
-  private searchInput!: HTMLInputElement;
-  private confirmBtn!: HTMLButtonElement;
+  private listEl: HTMLElement | null = null;
+  private searchInput: HTMLInputElement | null = null;
+  private confirmBtn: HTMLButtonElement | null = null;
+  private focusTimeoutId: number | null = null;
+  private readonly modalDisposers: Array<() => void> = [];
+  private readonly listDisposers: Array<() => void> = [];
 
   constructor(
     app: App,
@@ -32,7 +35,13 @@ export class NotePickerModal extends Modal {
       cls: 'curraint-note-picker-modal__search',
       attr: { type: 'text', placeholder: 'Search notes\u2026', autocomplete: 'off' },
     });
-    this.searchInput.addEventListener('input', () => this.renderList());
+    const handleSearchInput = (): void => {
+      this.renderList();
+    };
+    this.searchInput.addEventListener('input', handleSearchInput);
+    this.modalDisposers.push(() => {
+      this.searchInput?.removeEventListener('input', handleSearchInput);
+    });
 
     this.listEl = contentEl.createEl('ul', {
       cls: 'curraint-note-picker-modal__list',
@@ -52,30 +61,53 @@ export class NotePickerModal extends Modal {
       text: 'Cancel',
       cls: 'curraint-note-picker-modal__cancel',
     });
-    cancelBtn.addEventListener('click', () => this.close());
+    const handleCancelClick = (): void => {
+      this.close();
+    };
+    cancelBtn.addEventListener('click', handleCancelClick);
+    this.modalDisposers.push(() => {
+      cancelBtn.removeEventListener('click', handleCancelClick);
+    });
 
     this.confirmBtn = footer.createEl('button', {
       text: 'Add to context',
       cls: 'mod-cta curraint-note-picker-modal__confirm',
     });
-    this.confirmBtn.addEventListener('click', () => {
+    const handleConfirmClick = (): void => {
       const files = this.allFiles.filter((f) => this.checked.has(f.path));
       this.onConfirm(files);
       this.close();
+    };
+    this.confirmBtn.addEventListener('click', handleConfirmClick);
+    this.modalDisposers.push(() => {
+      this.confirmBtn?.removeEventListener('click', handleConfirmClick);
     });
 
     this.updateConfirmLabel();
 
     // Focus search after the modal renders.
-    window.setTimeout(() => this.searchInput.focus(), 0);
+    this.focusTimeoutId = window.setTimeout(() => this.searchInput?.focus(), 0);
   }
 
   onClose(): void {
+    this.clearDisposers(this.listDisposers);
+    this.clearDisposers(this.modalDisposers);
+    if (this.focusTimeoutId !== null) {
+      window.clearTimeout(this.focusTimeoutId);
+      this.focusTimeoutId = null;
+    }
+    this.listEl = null;
+    this.searchInput = null;
+    this.confirmBtn = null;
+    this.allFiles = [];
     this.contentEl.empty();
   }
 
   private renderList(): void {
+    if (!this.listEl) return;
+
     const query = this.searchInput?.value.toLowerCase() ?? '';
+    this.clearDisposers(this.listDisposers);
     this.listEl.empty();
 
     const filtered = query
@@ -90,7 +122,7 @@ export class NotePickerModal extends Modal {
 
     if (filtered.length > MAX_VISIBLE) {
       this.listEl.createEl('li', {
-        text: `\u2026 ${filtered.length - MAX_VISIBLE} more \u2014 refine the search to narrow results`,
+        text: `\u2026 ${filtered.length - MAX_VISIBLE} more - refine the search to narrow results`,
         cls: 'curraint-note-picker-modal__overflow',
       });
     }
@@ -105,8 +137,10 @@ export class NotePickerModal extends Modal {
 
   private renderItem(file: TFile): void {
     const isChecked = this.checked.has(file.path);
+    const listEl = this.listEl;
+    if (!listEl) return;
 
-    const item = this.listEl.createEl('li', {
+    const item = listEl.createEl('li', {
       cls: 'curraint-note-picker-modal__item',
     });
     if (isChecked) item.addClass('is-checked');
@@ -149,10 +183,21 @@ export class NotePickerModal extends Modal {
       this.updateConfirmLabel();
     };
 
-    item.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement) !== checkbox) toggle();
+    const handleItemClick = (event: MouseEvent): void => {
+      if ((event.target as HTMLElement) !== checkbox) toggle();
+    };
+    const handleCheckboxChange = (): void => {
+      toggle();
+    };
+
+    item.addEventListener('click', handleItemClick);
+    checkbox.addEventListener('change', handleCheckboxChange);
+    this.listDisposers.push(() => {
+      item.removeEventListener('click', handleItemClick);
     });
-    checkbox.addEventListener('change', () => toggle());
+    this.listDisposers.push(() => {
+      checkbox.removeEventListener('change', handleCheckboxChange);
+    });
   }
 
   private updateConfirmLabel(): void {
@@ -160,5 +205,11 @@ export class NotePickerModal extends Modal {
     const count = this.checked.size;
     this.confirmBtn.textContent =
       count > 0 ? `Add ${count} note${count === 1 ? '' : 's'} to context` : 'Add to context';
+  }
+
+  private clearDisposers(disposers: Array<() => void>): void {
+    while (disposers.length > 0) {
+      disposers.pop()?.();
+    }
   }
 }

--- a/packages/obsidian-plugin/src/chat/note-picker-modal.ts
+++ b/packages/obsidian-plugin/src/chat/note-picker-modal.ts
@@ -1,0 +1,164 @@
+import { App, Modal, TFile } from 'obsidian';
+
+const MAX_VISIBLE = 50;
+
+export class NotePickerModal extends Modal {
+  private readonly alreadySelected: ReadonlySet<string>;
+  private readonly onConfirm: (files: TFile[]) => void;
+  private checked: Set<string>;
+  private allFiles: TFile[] = [];
+  private listEl!: HTMLElement;
+  private searchInput!: HTMLInputElement;
+  private confirmBtn!: HTMLButtonElement;
+
+  constructor(
+    app: App,
+    alreadySelected: string[],
+    onConfirm: (files: TFile[]) => void
+  ) {
+    super(app);
+    this.alreadySelected = new Set(alreadySelected);
+    this.checked = new Set(alreadySelected);
+    this.onConfirm = onConfirm;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.addClass('curraint-note-picker-modal');
+
+    contentEl.createEl('h2', { text: 'Add note context' });
+
+    this.searchInput = contentEl.createEl('input', {
+      cls: 'curraint-note-picker-modal__search',
+      attr: { type: 'text', placeholder: 'Search notes\u2026', autocomplete: 'off' },
+    });
+    this.searchInput.addEventListener('input', () => this.renderList());
+
+    this.listEl = contentEl.createEl('ul', {
+      cls: 'curraint-note-picker-modal__list',
+    });
+
+    this.allFiles = this.app.vault
+      .getMarkdownFiles()
+      .sort((a, b) => b.stat.mtime - a.stat.mtime);
+
+    this.renderList();
+
+    const footer = contentEl.createEl('div', {
+      cls: 'curraint-note-picker-modal__footer',
+    });
+
+    const cancelBtn = footer.createEl('button', {
+      text: 'Cancel',
+      cls: 'curraint-note-picker-modal__cancel',
+    });
+    cancelBtn.addEventListener('click', () => this.close());
+
+    this.confirmBtn = footer.createEl('button', {
+      text: 'Add to context',
+      cls: 'mod-cta curraint-note-picker-modal__confirm',
+    });
+    this.confirmBtn.addEventListener('click', () => {
+      const files = this.allFiles.filter((f) => this.checked.has(f.path));
+      this.onConfirm(files);
+      this.close();
+    });
+
+    this.updateConfirmLabel();
+
+    // Focus search after the modal renders.
+    window.setTimeout(() => this.searchInput.focus(), 0);
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private renderList(): void {
+    const query = this.searchInput?.value.toLowerCase() ?? '';
+    this.listEl.empty();
+
+    const filtered = query
+      ? this.allFiles.filter((f) => f.path.toLowerCase().includes(query))
+      : this.allFiles;
+
+    const slice = filtered.slice(0, MAX_VISIBLE);
+
+    for (const file of slice) {
+      this.renderItem(file);
+    }
+
+    if (filtered.length > MAX_VISIBLE) {
+      this.listEl.createEl('li', {
+        text: `\u2026 ${filtered.length - MAX_VISIBLE} more \u2014 refine the search to narrow results`,
+        cls: 'curraint-note-picker-modal__overflow',
+      });
+    }
+
+    if (slice.length === 0) {
+      this.listEl.createEl('li', {
+        text: 'No notes match your search.',
+        cls: 'curraint-note-picker-modal__empty',
+      });
+    }
+  }
+
+  private renderItem(file: TFile): void {
+    const isChecked = this.checked.has(file.path);
+
+    const item = this.listEl.createEl('li', {
+      cls: 'curraint-note-picker-modal__item',
+    });
+    if (isChecked) item.addClass('is-checked');
+
+    const checkbox = item.createEl('input', {
+      cls: 'curraint-note-picker-modal__checkbox',
+      attr: { type: 'checkbox' },
+    }) as HTMLInputElement;
+    checkbox.checked = isChecked;
+
+    const labelEl = item.createEl('label', {
+      cls: 'curraint-note-picker-modal__label',
+    });
+
+    labelEl.createEl('span', {
+      text: file.basename,
+      cls: 'curraint-note-picker-modal__basename',
+    });
+
+    const folder = file.parent?.path && file.parent.path !== '/'
+      ? file.parent.path
+      : '';
+    if (folder) {
+      labelEl.createEl('span', {
+        text: folder,
+        cls: 'curraint-note-picker-modal__folder',
+      });
+    }
+
+    const toggle = (): void => {
+      if (this.checked.has(file.path)) {
+        this.checked.delete(file.path);
+        checkbox.checked = false;
+        item.removeClass('is-checked');
+      } else {
+        this.checked.add(file.path);
+        checkbox.checked = true;
+        item.addClass('is-checked');
+      }
+      this.updateConfirmLabel();
+    };
+
+    item.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement) !== checkbox) toggle();
+    });
+    checkbox.addEventListener('change', () => toggle());
+  }
+
+  private updateConfirmLabel(): void {
+    if (!this.confirmBtn) return;
+    const count = this.checked.size;
+    this.confirmBtn.textContent =
+      count > 0 ? `Add ${count} note${count === 1 ? '' : 's'} to context` : 'Add to context';
+  }
+}

--- a/packages/obsidian-plugin/src/chat/relative-date.test.ts
+++ b/packages/obsidian-plugin/src/chat/relative-date.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { relativeDate } from './relative-date';
+
+describe('relativeDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-26T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns just now for recent timestamps', () => {
+    expect(relativeDate(Date.now() - 30_000)).toBe('just now');
+  });
+
+  it('returns minutes for timestamps under one hour old', () => {
+    expect(relativeDate(Date.now() - 5 * 60_000)).toBe('5m ago');
+  });
+
+  it('returns hours for timestamps under one day old', () => {
+    expect(relativeDate(Date.now() - 3 * 60 * 60_000)).toBe('3h ago');
+  });
+
+  it('returns days for older timestamps', () => {
+    expect(relativeDate(Date.now() - 2 * 24 * 60 * 60_000)).toBe('2d ago');
+  });
+
+  it('treats future timestamps as just now', () => {
+    expect(relativeDate(Date.now() + 60_000)).toBe('just now');
+  });
+});

--- a/packages/obsidian-plugin/src/chat/relative-date.test.ts
+++ b/packages/obsidian-plugin/src/chat/relative-date.test.ts
@@ -15,6 +15,15 @@ describe('relativeDate', () => {
     expect(relativeDate(Date.now() - 30_000)).toBe('just now');
   });
 
+  it('handles boundary transitions between relative date units', () => {
+    expect(relativeDate(Date.now() - 59_000)).toBe('just now');
+    expect(relativeDate(Date.now() - 60_000)).toBe('1m ago');
+    expect(relativeDate(Date.now() - 3_599_000)).toBe('59m ago');
+    expect(relativeDate(Date.now() - 3_600_000)).toBe('1h ago');
+    expect(relativeDate(Date.now() - 86_399_000)).toBe('23h ago');
+    expect(relativeDate(Date.now() - 86_400_000)).toBe('1d ago');
+  });
+
   it('returns minutes for timestamps under one hour old', () => {
     expect(relativeDate(Date.now() - 5 * 60_000)).toBe('5m ago');
   });

--- a/packages/obsidian-plugin/src/chat/relative-date.ts
+++ b/packages/obsidian-plugin/src/chat/relative-date.ts
@@ -1,0 +1,7 @@
+export function relativeDate(updatedAt: number): string {
+  const diff = Math.floor((Date.now() - updatedAt) / 1000);
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}

--- a/packages/obsidian-plugin/src/chat/session-manager.test.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.test.ts
@@ -19,7 +19,6 @@ import {
 } from '@curraint/core';
 import type { ChatSessionCore, ChatSessionSubscriber, ChatSessionTransport } from '@curraint/core';
 import { ConversationRegistry } from './session-manager';
-import type { ConversationSlot } from './session-manager';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/obsidian-plugin/src/chat/session-manager.test.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @curraint/core before importing ConversationRegistry.
+vi.mock('@curraint/core', () => {
+  return {
+    createChatSessionCore: vi.fn(() => makeMockCore()),
+    generateSessionId: vi.fn(() => 'mock-session-id'),
+    deriveTitle: vi.fn((msg: string) => msg.slice(0, 60)),
+    saveSession: vi.fn(),
+    getSession: vi.fn(),
+  };
+});
+
+import {
+  createChatSessionCore,
+  generateSessionId,
+  deriveTitle,
+  saveSession,
+} from '@curraint/core';
+import type { ChatSessionCore, ChatSessionSubscriber, ChatSessionTransport } from '@curraint/core';
+import { ConversationRegistry } from './session-manager';
+import type { ConversationSlot } from './session-manager';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ConvMessage = { role: string; content: string };
+
+type MockCore = ChatSessionCore & {
+  _triggerStateChange: (isSending: boolean, conversation?: ConvMessage[]) => void;
+};
+
+function makeMockCore(initialConversation: ConvMessage[] = []): MockCore {
+  const subscribers = new Set<ChatSessionSubscriber>();
+  let currentConversation = initialConversation as import('@curraint/core').ChatMessage[];
+  let currentIsSending = false;
+
+  const core = {
+    getState: vi.fn(() => ({
+      conversation: currentConversation,
+      status: '',
+      isSending: currentIsSending,
+      isStopping: false,
+    })),
+    subscribe: vi.fn((sub: ChatSessionSubscriber) => {
+      subscribers.add(sub);
+      // Fire immediately with current (idle) state, matching real implementation.
+      sub.onStateChange?.({
+        conversation: currentConversation,
+        status: '',
+        isSending: false,
+        isStopping: false,
+      });
+      return () => subscribers.delete(sub);
+    }),
+    submitPrompt: vi.fn(),
+    editUserMessage: vi.fn(),
+    retryLastMessage: vi.fn(),
+    stopResponse: vi.fn(),
+    clearConversation: vi.fn(),
+    loadConversation: vi.fn((msgs) => {
+      currentConversation = msgs;
+      for (const sub of subscribers) {
+        sub.onStateChange?.({
+          conversation: currentConversation,
+          status: '',
+          isSending: false,
+          isStopping: false,
+        });
+      }
+    }),
+    // Test helper - simulate a state change
+    _triggerStateChange: (isSending: boolean, conversation?: ConvMessage[]) => {
+      if (conversation) currentConversation = conversation as import('@curraint/core').ChatMessage[];
+      currentIsSending = isSending;
+      for (const sub of subscribers) {
+        sub.onStateChange?.({
+          conversation: currentConversation,
+          status: '',
+          isSending,
+          isStopping: false,
+        });
+      }
+    },
+  } as unknown as MockCore;
+
+  return core;
+}
+
+function makeTransport(): ChatSessionTransport {
+  return { streamChat: vi.fn() };
+}
+
+function makeCoreForCall(n: number): MockCore {
+  const calls = vi.mocked(createChatSessionCore).mock.results;
+  return calls[n]?.value as MockCore;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe('ConversationRegistry - lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createChatSessionCore).mockImplementation(() => makeMockCore());
+  });
+
+  it('starts with no active core before init()', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    expect(reg.getActiveSlot()).toBeNull();
+  });
+
+  it('creates the initial slot on init()', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    expect(reg.getActiveSlot()).not.toBeNull();
+    expect(createChatSessionCore).toHaveBeenCalledTimes(1);
+  });
+
+  it('getOrCreateActive() returns the same core on repeated calls', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    const a = reg.getOrCreateActive();
+    const b = reg.getOrCreateActive();
+    expect(a).toBe(b);
+  });
+
+  it('newConversation() changes the active key and creates a new core', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    const before = reg.activeKey;
+
+    reg.newConversation();
+
+    expect(reg.activeKey).not.toBe(before);
+    expect(createChatSessionCore).toHaveBeenCalledTimes(2);
+  });
+
+  it('getOrCreateActive() after newConversation() returns the new core', () => {
+    vi.mocked(createChatSessionCore)
+      .mockImplementationOnce(() => makeMockCore()) // init slot
+      .mockImplementationOnce(() => makeMockCore()); // new conv slot
+
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    const firstCore = reg.getOrCreateActive();
+
+    reg.newConversation();
+    const secondCore = reg.getOrCreateActive();
+
+    expect(secondCore).not.toBe(firstCore);
+  });
+
+  it('stopActive() calls stopResponse on the active core', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    reg.stopActive();
+    const slot = makeCoreForCall(0);
+    expect(slot.stopResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() unsubscribes all slots', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    reg.newConversation();
+
+    reg.destroy();
+
+    // After destroy the registry is empty.
+    expect(reg.getActiveSlot()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSession
+// ---------------------------------------------------------------------------
+
+describe('ConversationRegistry - loadSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createChatSessionCore).mockImplementation(() => makeMockCore());
+  });
+
+  const saved = {
+    id: 'saved-123',
+    title: 'Past chat',
+    createdAt: 1000,
+    updatedAt: 2000,
+    messages: [
+      { role: 'user' as const, content: 'Hello' },
+      { role: 'assistant' as const, content: 'Hi there', timestamp: 0 },
+    ],
+  };
+
+  it('changes the active key to the session id', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    reg.loadSession(saved);
+    expect(reg.activeKey).toBe(saved.id);
+  });
+
+  it('calls loadConversation with the saved messages', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    reg.loadSession(saved);
+    const core = reg.getOrCreateActive();
+    expect(core.loadConversation).toHaveBeenCalledWith(saved.messages);
+  });
+
+  it('re-uses a streaming background slot matching the session id', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+
+    // Simulate the initial slot streaming for this saved session
+    const initCore = makeCoreForCall(0) as MockCore;
+    const initSlot = reg.getActiveSlot()!;
+    initSlot.sessionId = saved.id;
+    initCore._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+
+    const keyBeforeSwitch = reg.activeKey;
+
+    // Switch to a new conversation, then load back the streaming session.
+    reg.newConversation();
+    reg.loadSession(saved);
+
+    // Should have switched back to the still-streaming slot, not created a new core.
+    expect(reg.activeKey).toBe(keyBeforeSwitch);
+    expect(createChatSessionCore).toHaveBeenCalledTimes(2); // init + newConversation only
+  });
+
+  it('replaces a stale idle slot when reloading the same session', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+
+    reg.loadSession(saved);
+    const firstCore = reg.getOrCreateActive();
+
+    reg.loadSession(saved);
+    const secondCore = reg.getOrCreateActive();
+
+    expect(secondCore).not.toBe(firstCore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-save - triggered by registry's persistent subscription
+// ---------------------------------------------------------------------------
+
+describe('ConversationRegistry - autoSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(generateSessionId).mockReturnValue('mock-session-id');
+    vi.mocked(deriveTitle).mockImplementation((msg: string) => msg.slice(0, 60));
+    vi.mocked(createChatSessionCore).mockImplementation(() => makeMockCore());
+  });
+
+  it('does not save when getEnableSessionSaving returns false', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    const core = makeCoreForCall(0);
+    core._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+    expect(saveSession).not.toHaveBeenCalled();
+  });
+
+  it('saves eagerly when isSending transitions false -> true', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+
+    expect(saveSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves again when isSending transitions true -> false', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+    core._triggerStateChange(false, [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'World' },
+    ]);
+
+    expect(saveSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not save when there are no user messages', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'system', content: 'You are helpful.' }]);
+
+    expect(saveSession).not.toHaveBeenCalled();
+  });
+
+  it('filters system messages before saving', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hi' },
+    ]);
+
+    const saved = vi.mocked(saveSession).mock.calls[0]![0];
+    expect(saved.messages.every((m) => m.role !== 'system')).toBe(true);
+  });
+
+  it('strips a trailing empty assistant placeholder before saving', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: '' },
+    ]);
+
+    const saved = vi.mocked(saveSession).mock.calls[0]![0];
+    expect(saved.messages.filter((m) => m.role === 'assistant')).toHaveLength(0);
+  });
+
+  it('generates a session id on the first save', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+
+    expect(generateSessionId).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(saveSession).mock.calls[0]![0].id).toBe('mock-session-id');
+  });
+
+  it('reuses the same session id on subsequent saves', () => {
+    vi.mocked(generateSessionId)
+      .mockReturnValueOnce('first-id')
+      .mockReturnValueOnce('second-id');
+
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'Hello' }]);
+    core._triggerStateChange(false, [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'World' },
+    ]);
+
+    expect(generateSessionId).toHaveBeenCalledTimes(1);
+    const calls = vi.mocked(saveSession).mock.calls;
+    expect(calls[0]![0].id).toBe('first-id');
+    expect(calls[1]![0].id).toBe('first-id');
+  });
+
+  it('derives title from the first user message', () => {
+    vi.mocked(deriveTitle).mockReturnValue('My question');
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'My question' }]);
+
+    expect(deriveTitle).toHaveBeenCalledWith('My question');
+    expect(vi.mocked(saveSession).mock.calls[0]![0].title).toBe('My question');
+  });
+
+  it('keeps the title stable across multiple saves', () => {
+    vi.mocked(deriveTitle).mockReturnValue('First msg');
+    const reg = new ConversationRegistry(() => makeTransport(), () => true);
+    reg.init();
+    const core = makeCoreForCall(0);
+
+    core._triggerStateChange(true, [{ role: 'user', content: 'First msg' }]);
+    core._triggerStateChange(false, [
+      { role: 'user', content: 'First msg' },
+      { role: 'assistant', content: 'Response' },
+    ]);
+
+    expect(deriveTitle).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Background slot cleanup
+// ---------------------------------------------------------------------------
+
+describe('ConversationRegistry - background slot cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createChatSessionCore).mockImplementation(() => makeMockCore());
+  });
+
+  it('removes a background slot from the registry when its stream finishes', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+
+    const initialKey = reg.activeKey;
+    const initCore = makeCoreForCall(0);
+
+    // Start streaming on the initial slot.
+    initCore._triggerStateChange(true, [{ role: 'user', content: 'Hi' }]);
+
+    // Switch to a new conversation - initial slot becomes background.
+    reg.newConversation();
+    expect(reg.activeKey).not.toBe(initialKey);
+
+    // Background slot finishes - it should remove itself.
+    initCore._triggerStateChange(false, [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello' },
+    ]);
+
+    // The background slot should no longer be reachable as a live streaming slot.
+    // After cleanup, loading the same session id should create a fresh slot.
+    expect(createChatSessionCore).toHaveBeenCalledTimes(2); // init + newConversation
+  });
+});
+
+// ---------------------------------------------------------------------------

--- a/packages/obsidian-plugin/src/chat/session-manager.test.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.test.ts
@@ -16,6 +16,7 @@ import {
   generateSessionId,
   deriveTitle,
   saveSession,
+  getSession,
 } from '@curraint/core';
 import type { ChatSessionCore, ChatSessionSubscriber, ChatSessionTransport } from '@curraint/core';
 import { ConversationRegistry } from './session-manager';
@@ -240,6 +241,61 @@ describe('ConversationRegistry - loadSession', () => {
     const secondCore = reg.getOrCreateActive();
 
     expect(secondCore).not.toBe(firstCore);
+  });
+
+  it('removes a mismatched idle slot key before loading the canonical saved session key', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+    reg.newConversation();
+
+    const oldKey = reg.activeKey;
+    const oldCore = reg.getOrCreateActive();
+    const oldSlot = reg.getActiveSlot()!;
+    oldSlot.sessionId = saved.id;
+
+    reg.loadSession(saved);
+
+    const newCore = reg.getOrCreateActive();
+    const slots = (reg as unknown as { slots: Map<string, unknown> }).slots;
+
+    expect(reg.activeKey).toBe(saved.id);
+    expect(newCore).not.toBe(oldCore);
+    expect(slots.has(oldKey)).toBe(false);
+    expect(slots.has(saved.id)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renameActive
+// ---------------------------------------------------------------------------
+
+describe('ConversationRegistry - renameActive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createChatSessionCore).mockImplementation(() => makeMockCore());
+  });
+
+  it('persists clearing the title for a saved session', () => {
+    const reg = new ConversationRegistry(() => makeTransport(), () => false);
+    reg.init();
+
+    const savedSession = {
+      id: 'saved-123',
+      title: 'Existing title',
+      createdAt: 1000,
+      updatedAt: 2000,
+      messages: [{ role: 'user' as const, content: 'Hello' }],
+    };
+    vi.mocked(getSession).mockReturnValue(savedSession);
+
+    reg.loadSession(savedSession);
+    reg.renameActive('   ');
+
+    expect(reg.getActiveSlot()?.title).toBe('');
+    expect(saveSession).toHaveBeenCalledWith({
+      ...savedSession,
+      title: '',
+    });
   });
 });
 

--- a/packages/obsidian-plugin/src/chat/session-manager.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.ts
@@ -100,7 +100,7 @@ export class ConversationRegistry {
 
   /** Stop the active slot's stream if it is sending. */
   stopActive(): void {
-    void this.slots.get(this._activeKey)?.core.stopResponse();
+    this.slots.get(this._activeKey)?.core.stopResponse()?.catch(() => {});
   }
 
   /** Rename the active conversation, persisting to storage if already saved. */

--- a/packages/obsidian-plugin/src/chat/session-manager.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.ts
@@ -100,7 +100,9 @@ export class ConversationRegistry {
 
   /** Stop the active slot's stream if it is sending. */
   stopActive(): void {
-    this.slots.get(this._activeKey)?.core.stopResponse()?.catch(() => {});
+    this.slots.get(this._activeKey)?.core.stopResponse()?.catch((error: unknown) => {
+      console.error(`Curraint: stopResponse failed for slot ${this._activeKey}`, error);
+    });
   }
 
   /** Rename the active conversation, persisting to storage if already saved. */

--- a/packages/obsidian-plugin/src/chat/session-manager.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.ts
@@ -83,12 +83,12 @@ export class ConversationRegistry {
       }
     }
 
-    // Replace a stale idle slot under the same key if one exists.
     const key = saved.id;
-    const existing = this.slots.get(key);
-    if (existing) {
-      existing.unsubscribe();
-      this.slots.delete(key);
+    for (const [existingKey, existingSlot] of Array.from(this.slots.entries())) {
+      if (existingSlot.sessionId === saved.id) {
+        existingSlot.unsubscribe();
+        this.slots.delete(existingKey);
+      }
     }
 
     const slot = this.createSlot(key, saved.id, saved.createdAt);
@@ -108,8 +108,8 @@ export class ConversationRegistry {
     const slot = this.slots.get(this._activeKey);
     if (!slot) return;
     const trimmed = title.trim();
-    slot.title = trimmed || null;
-    if (slot.sessionId && trimmed) {
+    slot.title = trimmed || '';
+    if (slot.sessionId) {
       const saved = getSession(slot.sessionId);
       if (saved) {
         saveSession({ ...saved, title: trimmed });
@@ -140,7 +140,7 @@ export class ConversationRegistry {
       slot.sessionCreatedAt = Date.now();
     }
     const firstUserContent = msgs.find((m) => m.role === 'user')!.content;
-    if (!slot.title) {
+    if (slot.title === null) {
       slot.title = deriveTitle(firstUserContent);
     }
     saveSession({

--- a/packages/obsidian-plugin/src/chat/session-manager.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.ts
@@ -3,6 +3,7 @@ import {
   generateSessionId,
   deriveTitle,
   saveSession,
+  getSession,
 } from '@curraint/core';
 import type { ChatSessionCore, ChatSessionTransport, ChatMessage, SavedSession } from '@curraint/core';
 
@@ -100,6 +101,20 @@ export class ConversationRegistry {
   /** Stop the active slot's stream if it is sending. */
   stopActive(): void {
     void this.slots.get(this._activeKey)?.core.stopResponse();
+  }
+
+  /** Rename the active conversation, persisting to storage if already saved. */
+  renameActive(title: string): void {
+    const slot = this.slots.get(this._activeKey);
+    if (!slot) return;
+    const trimmed = title.trim();
+    slot.title = trimmed || null;
+    if (slot.sessionId && trimmed) {
+      const saved = getSession(slot.sessionId);
+      if (saved) {
+        saveSession({ ...saved, title: trimmed });
+      }
+    }
   }
 
   /** Release all slots and their core subscriptions. */

--- a/packages/obsidian-plugin/src/chat/session-manager.ts
+++ b/packages/obsidian-plugin/src/chat/session-manager.ts
@@ -1,0 +1,179 @@
+import {
+  createChatSessionCore,
+  generateSessionId,
+  deriveTitle,
+  saveSession,
+} from '@curraint/core';
+import type { ChatSessionCore, ChatSessionTransport, ChatMessage, SavedSession } from '@curraint/core';
+
+export type TransportFactory = () => ChatSessionTransport;
+
+export type ConversationSlot = {
+  core: ChatSessionCore;
+  sessionId: string | null;
+  sessionCreatedAt: number;
+  title: string | null;
+  prevIsSending: boolean;
+  unsubscribe: () => void;
+};
+
+const INITIAL_SLOT_KEY = '__new__';
+
+/**
+ * Manages multiple independent conversation slots. Each slot has its own
+ * ChatSessionCore so conversations can stream in the background while the
+ * user switches to a different conversation. Only the active slot drives the
+ * visible UI; background slots auto-save and clean themselves up when done.
+ */
+export class ConversationRegistry {
+  private readonly transportFactory: TransportFactory;
+  private readonly getEnableSessionSaving: () => boolean;
+  private readonly slots = new Map<string, ConversationSlot>();
+  private _activeKey = INITIAL_SLOT_KEY;
+
+  constructor(transportFactory: TransportFactory, getEnableSessionSaving: () => boolean) {
+    this.transportFactory = transportFactory;
+    this.getEnableSessionSaving = getEnableSessionSaving;
+  }
+
+  get activeKey(): string {
+    return this._activeKey;
+  }
+
+  /** Create the initial slot. Must be called once after construction. */
+  init(): void {
+    const slot = this.createSlot(INITIAL_SLOT_KEY, null, 0);
+    this.slots.set(INITIAL_SLOT_KEY, slot);
+  }
+
+  /** Return the active slot's core, creating the slot if it is missing. */
+  getOrCreateActive(): ChatSessionCore {
+    if (!this.slots.has(this._activeKey)) {
+      const slot = this.createSlot(this._activeKey, null, 0);
+      this.slots.set(this._activeKey, slot);
+    }
+    return this.slots.get(this._activeKey)!.core;
+  }
+
+  /** Return the active slot, or null if none exists. */
+  getActiveSlot(): ConversationSlot | null {
+    return this.slots.get(this._activeKey) ?? null;
+  }
+
+  /** Create a fresh idle conversation and make it the active slot. */
+  newConversation(): void {
+    const key = `conv-${Date.now()}`;
+    const slot = this.createSlot(key, null, 0);
+    this.slots.set(key, slot);
+    this._activeKey = key;
+  }
+
+  /**
+   * Activate a saved session. If the session is already streaming in the
+   * background, re-attach the view to it without interrupting the stream.
+   * Otherwise create a fresh idle slot and load the saved messages into it.
+   */
+  loadSession(saved: SavedSession): void {
+    // Re-attach to a background slot that is still streaming this session.
+    for (const [k, slot] of this.slots) {
+      if (slot.sessionId === saved.id && slot.core.getState().isSending) {
+        this._activeKey = k;
+        return;
+      }
+    }
+
+    // Replace a stale idle slot under the same key if one exists.
+    const key = saved.id;
+    const existing = this.slots.get(key);
+    if (existing) {
+      existing.unsubscribe();
+      this.slots.delete(key);
+    }
+
+    const slot = this.createSlot(key, saved.id, saved.createdAt);
+    slot.title = saved.title;
+    this.slots.set(key, slot);
+    this._activeKey = key;
+    slot.core.loadConversation(saved.messages);
+  }
+
+  /** Stop the active slot's stream if it is sending. */
+  stopActive(): void {
+    void this.slots.get(this._activeKey)?.core.stopResponse();
+  }
+
+  /** Release all slots and their core subscriptions. */
+  destroy(): void {
+    for (const slot of this.slots.values()) {
+      slot.unsubscribe();
+    }
+    this.slots.clear();
+  }
+
+  private autoSave(slot: ConversationSlot, messages: ChatMessage[]): void {
+    if (!this.getEnableSessionSaving()) return;
+
+    let msgs = messages.filter((m) => m.role !== 'system');
+    // Strip a trailing empty assistant placeholder (present while still streaming).
+    if (msgs[msgs.length - 1]?.role === 'assistant' && msgs[msgs.length - 1]!.content === '') {
+      msgs = msgs.slice(0, -1);
+    }
+    if (!msgs.some((m) => m.role === 'user')) return;
+
+    if (!slot.sessionId) {
+      slot.sessionId = generateSessionId();
+      slot.sessionCreatedAt = Date.now();
+    }
+    const firstUserContent = msgs.find((m) => m.role === 'user')!.content;
+    if (!slot.title) {
+      slot.title = deriveTitle(firstUserContent);
+    }
+    saveSession({
+      id: slot.sessionId,
+      title: slot.title,
+      createdAt: slot.sessionCreatedAt,
+      updatedAt: Date.now(),
+      messages: msgs,
+    });
+  }
+
+  private createSlot(
+    key: string,
+    sessionId: string | null,
+    sessionCreatedAt: number
+  ): ConversationSlot {
+    const core = createChatSessionCore(this.transportFactory());
+    const slot: ConversationSlot = {
+      core,
+      sessionId,
+      sessionCreatedAt,
+      title: null,
+      prevIsSending: false,
+      unsubscribe: () => {},
+    };
+
+    slot.unsubscribe = core.subscribe({
+      onStateChange: (state) => {
+        const wasSending = slot.prevIsSending;
+        slot.prevIsSending = state.isSending;
+
+        if (!wasSending && state.isSending) {
+          // Save eagerly so the session appears in the list while streaming.
+          this.autoSave(slot, state.conversation);
+          return;
+        }
+
+        if (wasSending && !state.isSending) {
+          this.autoSave(slot, state.conversation);
+          // Background slots remove themselves once their stream finishes.
+          if (key !== this._activeKey) {
+            slot.unsubscribe();
+            this.slots.delete(key);
+          }
+        }
+      },
+    });
+
+    return slot;
+  }
+}

--- a/packages/obsidian-plugin/src/chat/sessions-modal.ts
+++ b/packages/obsidian-plugin/src/chat/sessions-modal.ts
@@ -95,12 +95,16 @@ export class SessionsModal extends Modal {
       }).open();
     });
 
-    renameBtn.addEventListener('click', () => {
-      this.beginInlineRename(summary, titleSpan);
-    });
+    renameBtn.onclick = () => {
+      this.beginInlineRename(summary, titleSpan, renameBtn);
+    };
   }
 
-  private beginInlineRename(summary: SessionSummary, titleSpan: HTMLElement): void {
+  private beginInlineRename(
+    summary: SessionSummary,
+    titleSpan: HTMLElement,
+    renameBtn: HTMLElement | null = null
+  ): void {
     const current = titleSpan.textContent ?? '';
     const input = document.createElement('input');
     input.type = 'text';
@@ -111,13 +115,17 @@ export class SessionsModal extends Modal {
 
     let committed = false;
 
-    const restoreSpan = (text: string): void => {
+    const restoreSpan = (text: string, nextRenameBtn: HTMLElement | null): void => {
       const span = createEl('span', { text, cls: 'curraint-sessions-modal__title' });
       input.replaceWith(span);
-      const renameBtn = span.parentElement?.querySelector(
+      const button = nextRenameBtn ?? span.parentElement?.querySelector(
         '.curraint-sessions-modal__rename'
       ) as HTMLElement | null;
-      renameBtn?.addEventListener('click', () => this.beginInlineRename(summary, span));
+      if (button) {
+        button.onclick = () => {
+          this.beginInlineRename(summary, span, button);
+        };
+      }
     };
 
     const commit = (): void => {
@@ -130,14 +138,14 @@ export class SessionsModal extends Modal {
       if (saved) {
         saveSession({ ...saved, title: newTitle });
       }
-      restoreSpan(newTitle);
+      restoreSpan(newTitle, renameBtn);
     };
 
     input.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Enter') { e.preventDefault(); commit(); }
       if (e.key === 'Escape') {
         committed = true;
-        restoreSpan(current);
+        restoreSpan(current, renameBtn);
       }
     });
     input.addEventListener('blur', commit);

--- a/packages/obsidian-plugin/src/chat/sessions-modal.ts
+++ b/packages/obsidian-plugin/src/chat/sessions-modal.ts
@@ -1,0 +1,91 @@
+import { App, Modal } from 'obsidian';
+import { listSessions, getSession, deleteSession } from '@curraint/core';
+import type { SavedSession, SessionSummary } from '@curraint/core';
+
+function relativeDate(updatedAt: number): string {
+  const diff = Math.floor((Date.now() - updatedAt) / 1000);
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export class SessionsModal extends Modal {
+  private readonly onLoad: (session: SavedSession) => void;
+
+  constructor(app: App, onLoad: (session: SavedSession) => void) {
+    super(app);
+    this.onLoad = onLoad;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.addClass('curraint-sessions-modal');
+    contentEl.createEl('h2', { text: 'Saved conversations' });
+
+    const sessions = listSessions();
+
+    if (sessions.length === 0) {
+      contentEl.createEl('p', {
+        text: 'No saved conversations yet. Enable "Save sessions" in settings to start saving.',
+        cls: 'curraint-sessions-modal__empty',
+      });
+      return;
+    }
+
+    const list = contentEl.createEl('ul', { cls: 'curraint-sessions-modal__list' });
+    for (const summary of sessions) {
+      this.renderItem(list, summary);
+    }
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private renderItem(list: HTMLElement, summary: SessionSummary): void {
+    const item = list.createEl('li', { cls: 'curraint-sessions-modal__item' });
+
+    const meta = item.createEl('div', { cls: 'curraint-sessions-modal__meta' });
+    meta.createEl('span', {
+      text: summary.title || 'Untitled',
+      cls: 'curraint-sessions-modal__title',
+    });
+    meta.createEl('span', {
+      text: `${summary.messageCount} messages \u00b7 ${relativeDate(summary.updatedAt)}`,
+      cls: 'curraint-sessions-modal__info',
+    });
+
+    const actions = item.createEl('div', { cls: 'curraint-sessions-modal__actions' });
+
+    const openBtn = actions.createEl('button', {
+      text: 'Open',
+      cls: 'mod-cta curraint-sessions-modal__open',
+    });
+    openBtn.addEventListener('click', () => {
+      const session = getSession(summary.id);
+      if (session) {
+        this.onLoad(session);
+      }
+      this.close();
+    });
+
+    const deleteBtn = actions.createEl('button', {
+      text: 'Delete',
+      cls: 'curraint-sessions-modal__delete',
+    });
+    deleteBtn.addEventListener('click', () => {
+      deleteSession(summary.id);
+      item.remove();
+      // Show empty state if the list is now empty
+      if (list.children.length === 0) {
+        list.replaceWith(
+          createEl('p', {
+            text: 'No saved conversations yet.',
+            cls: 'curraint-sessions-modal__empty',
+          })
+        );
+      }
+    });
+  }
+}

--- a/packages/obsidian-plugin/src/chat/sessions-modal.ts
+++ b/packages/obsidian-plugin/src/chat/sessions-modal.ts
@@ -1,15 +1,8 @@
-import { App, Modal, setIcon } from 'obsidian';
+import { App, Modal, Notice, setIcon } from 'obsidian';
 import { DeleteConfirmModal } from './delete-confirm-modal';
 import { listSessions, getSession, deleteSession, saveSession } from '@curraint/core';
 import type { SavedSession, SessionSummary } from '@curraint/core';
-
-function relativeDate(updatedAt: number): string {
-  const diff = Math.floor((Date.now() - updatedAt) / 1000);
-  if (diff < 60) return 'just now';
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
+import { relativeDate } from './relative-date';
 
 export class SessionsModal extends Modal {
   private readonly onLoad: (session: SavedSession) => void;
@@ -77,8 +70,10 @@ export class SessionsModal extends Modal {
       const session = getSession(summary.id);
       if (session) {
         this.onLoad(session);
+        this.close();
+        return;
       }
-      this.close();
+      new Notice('Could not load session.');
     });
 
     const deleteBtn = actions.createEl('button', {

--- a/packages/obsidian-plugin/src/chat/sessions-modal.ts
+++ b/packages/obsidian-plugin/src/chat/sessions-modal.ts
@@ -1,5 +1,6 @@
-import { App, Modal } from 'obsidian';
-import { listSessions, getSession, deleteSession } from '@curraint/core';
+import { App, Modal, setIcon } from 'obsidian';
+import { DeleteConfirmModal } from './delete-confirm-modal';
+import { listSessions, getSession, deleteSession, saveSession } from '@curraint/core';
 import type { SavedSession, SessionSummary } from '@curraint/core';
 
 function relativeDate(updatedAt: number): string {
@@ -47,10 +48,20 @@ export class SessionsModal extends Modal {
     const item = list.createEl('li', { cls: 'curraint-sessions-modal__item' });
 
     const meta = item.createEl('div', { cls: 'curraint-sessions-modal__meta' });
-    meta.createEl('span', {
+
+    const titleRow = meta.createEl('div', { cls: 'curraint-sessions-modal__title-row' });
+    const titleSpan = titleRow.createEl('span', {
       text: summary.title || 'Untitled',
       cls: 'curraint-sessions-modal__title',
     });
+
+    const renameBtn = titleRow.createEl('button', {
+      cls: 'curraint-sessions-modal__rename',
+      title: 'Rename',
+      attr: { 'aria-label': 'Rename conversation' },
+    });
+    setIcon(renameBtn, 'pencil');
+
     meta.createEl('span', {
       text: `${summary.messageCount} messages \u00b7 ${relativeDate(summary.updatedAt)}`,
       cls: 'curraint-sessions-modal__info',
@@ -75,17 +86,66 @@ export class SessionsModal extends Modal {
       cls: 'curraint-sessions-modal__delete',
     });
     deleteBtn.addEventListener('click', () => {
-      deleteSession(summary.id);
-      item.remove();
-      // Show empty state if the list is now empty
-      if (list.children.length === 0) {
-        list.replaceWith(
-          createEl('p', {
-            text: 'No saved conversations yet.',
-            cls: 'curraint-sessions-modal__empty',
-          })
-        );
-      }
+      new DeleteConfirmModal(this.app, summary.title || 'Untitled', () => {
+        deleteSession(summary.id);
+        item.remove();
+        if (list.children.length === 0) {
+          list.replaceWith(
+            createEl('p', {
+              text: 'No saved conversations yet.',
+              cls: 'curraint-sessions-modal__empty',
+            })
+          );
+        }
+      }).open();
+    });
+
+    renameBtn.addEventListener('click', () => {
+      this.beginInlineRename(summary, titleSpan);
     });
   }
+
+  private beginInlineRename(summary: SessionSummary, titleSpan: HTMLElement): void {
+    const current = titleSpan.textContent ?? '';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'curraint-sessions-modal__rename-input';
+    input.value = current;
+    titleSpan.replaceWith(input);
+    input.select();
+
+    let committed = false;
+
+    const restoreSpan = (text: string): void => {
+      const span = createEl('span', { text, cls: 'curraint-sessions-modal__title' });
+      input.replaceWith(span);
+      const renameBtn = span.parentElement?.querySelector(
+        '.curraint-sessions-modal__rename'
+      ) as HTMLElement | null;
+      renameBtn?.addEventListener('click', () => this.beginInlineRename(summary, span));
+    };
+
+    const commit = (): void => {
+      if (committed) return;
+      committed = true;
+      const trimmed = input.value.trim();
+      const newTitle = trimmed || current;
+      summary.title = newTitle;
+      const saved = getSession(summary.id);
+      if (saved) {
+        saveSession({ ...saved, title: newTitle });
+      }
+      restoreSpan(newTitle);
+    };
+
+    input.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      if (e.key === 'Escape') {
+        committed = true;
+        restoreSpan(current);
+      }
+    });
+    input.addEventListener('blur', commit);
+  }
 }
+

--- a/packages/obsidian-plugin/src/log.ts
+++ b/packages/obsidian-plugin/src/log.ts
@@ -1,0 +1,23 @@
+// Verbose logging helpers for plugin development.
+//
+// __DEV__ is injected at build time by esbuild:
+//   - true  during `pnpm dev` (watch mode)
+//   - false during `pnpm build` / `pnpm deploy`
+//
+// esbuild's tree-shaking eliminates all log() call-sites in production
+// builds because the `if (false)` branches are statically dead code.
+//
+// Usage:
+//   import { log } from './log';
+//   log('transport', 'sending request', { url, model });
+//
+// Logs appear in the Obsidian developer console (Ctrl+Shift+I / Cmd+Option+I)
+// tagged with "[curraint:<scope>]" so you can filter by "curraint".
+
+declare const __DEV__: boolean;
+
+export function log(scope: string, ...args: unknown[]): void {
+  if (__DEV__) {
+    console.debug(`[curraint:${scope}]`, ...args);
+  }
+}

--- a/packages/obsidian-plugin/src/main.test.ts
+++ b/packages/obsidian-plugin/src/main.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceLeaf } from 'obsidian';
+import CurraintPlugin from './main';
+import { ChatView, CHAT_VIEW_TYPE } from './chat/chat-view';
+
+describe('CurraintPlugin - unload', () => {
+  it('destroys chat registries before detaching chat leaves', () => {
+    const calls: string[] = [];
+    const destroyFirst = vi.fn(() => { calls.push('destroy:first'); });
+    const destroySecond = vi.fn(() => { calls.push('destroy:second'); });
+    const detachLeavesOfType = vi.fn(() => { calls.push('detach'); });
+
+    const firstView = Object.assign(Object.create(ChatView.prototype), {
+      destroyRegistry: destroyFirst,
+    });
+    const secondView = Object.assign(Object.create(ChatView.prototype), {
+      destroyRegistry: destroySecond,
+    });
+
+    const leaves = [
+      { view: firstView },
+      { view: secondView },
+    ] as WorkspaceLeaf[];
+
+    const plugin = new CurraintPlugin();
+    (plugin as CurraintPlugin & {
+      app: {
+        workspace: {
+          getLeavesOfType: (viewType: string) => WorkspaceLeaf[];
+          detachLeavesOfType: (viewType: string) => void;
+        };
+      };
+    }).app = {
+      workspace: {
+        getLeavesOfType: (viewType: string) => {
+          expect(viewType).toBe(CHAT_VIEW_TYPE);
+          return leaves;
+        },
+        detachLeavesOfType,
+      },
+    };
+
+    plugin.onunload();
+
+    expect(destroyFirst).toHaveBeenCalledTimes(1);
+    expect(destroySecond).toHaveBeenCalledTimes(1);
+    expect(detachLeavesOfType).toHaveBeenCalledWith(CHAT_VIEW_TYPE);
+    expect(calls).toEqual(['destroy:first', 'destroy:second', 'detach']);
+  });
+});

--- a/packages/obsidian-plugin/src/main.test.ts
+++ b/packages/obsidian-plugin/src/main.test.ts
@@ -1,7 +1,61 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Platform } from 'obsidian';
 import type { WorkspaceLeaf } from 'obsidian';
-import CurraintPlugin from './main';
+import CurraintPlugin, { DEFAULT_PLUGIN_SETTINGS } from './main';
 import { ChatView, CHAT_VIEW_TYPE } from './chat/chat-view';
+import { PROVIDER_CONFIGS } from '@curraint/core';
+import { createSecretsStrategy, generateMobileDeviceKey } from './secrets';
+
+vi.mock('./secrets', async () => {
+  const actual = await vi.importActual<typeof import('./secrets')>('./secrets');
+  return {
+    ...actual,
+    createSecretsStrategy: vi.fn(() => ({
+      encrypt: vi.fn(),
+      decrypt: vi.fn(),
+    })),
+    generateMobileDeviceKey: vi.fn(() => 'generated-mobile-key'),
+  };
+});
+
+describe('CurraintPlugin - mobile onload', () => {
+  beforeEach(() => {
+    Platform.isMobile = true;
+    Platform.isDesktop = false;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Platform.isMobile = false;
+    Platform.isDesktop = true;
+  });
+
+  it('saves settings once after applying all mobile migrations', async () => {
+    const plugin = new CurraintPlugin();
+    vi.spyOn(plugin, 'loadSettings').mockImplementation(async () => {
+      plugin.settings = {
+        ...DEFAULT_PLUGIN_SETTINGS,
+        provider: 'lmstudio',
+        baseUrl: 'http://127.0.0.1:1234/v1',
+        mobileDeviceKey: '',
+      };
+    });
+    const saveSettings = vi.spyOn(plugin, 'saveSettings').mockResolvedValue();
+    plugin.registerView = vi.fn();
+    plugin.addRibbonIcon = vi.fn();
+    plugin.addCommand = vi.fn();
+    plugin.addSettingTab = vi.fn();
+
+    await plugin.onload();
+
+    expect(generateMobileDeviceKey).toHaveBeenCalledTimes(1);
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    expect(plugin.settings.mobileDeviceKey).toBe('generated-mobile-key');
+    expect(plugin.settings.provider).toBe('openai');
+    expect(plugin.settings.baseUrl).toBe(PROVIDER_CONFIGS.openai.defaultBaseUrl);
+    expect(createSecretsStrategy).toHaveBeenCalledWith(true, 'generated-mobile-key');
+  });
+});
 
 describe('CurraintPlugin - unload', () => {
   it('destroys chat registries before detaching chat leaves', () => {

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -1,7 +1,13 @@
-import { Plugin } from 'obsidian';
+import { Plugin, Platform } from 'obsidian';
 import { CurraintSettingTab } from './settings-tab';
 import { ChatView, CHAT_VIEW_TYPE } from './chat/chat-view';
 import type { PluginSettings } from './types';
+import { PROVIDER_CONFIGS } from '@curraint/core';
+import {
+  type SecretsStrategy,
+  createSecretsStrategy,
+  generateMobileDeviceKey,
+} from './secrets';
 
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   provider: 'openai',
@@ -12,13 +18,35 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   contextMaxMessages: 40,
   contextMaxCharacters: 24000,
   enableSessionSaving: false,
+  mobileDeviceKey: '',
 };
 
 export default class CurraintPlugin extends Plugin {
   settings: PluginSettings = { ...DEFAULT_PLUGIN_SETTINGS };
+  secrets!: SecretsStrategy;
 
   async onload(): Promise<void> {
     await this.loadSettings();
+
+    if (Platform.isMobile) {
+      // Generate a device key on first mobile run - used by MobileSecretsStrategy.
+      if (!this.settings.mobileDeviceKey) {
+        this.settings.mobileDeviceKey = generateMobileDeviceKey();
+        await this.saveSettings();
+      }
+      // LM Studio requires a local server, which is not reachable from mobile.
+      // Reset to OpenAI if the provider was synced from a desktop vault.
+      if (this.settings.provider === 'lmstudio') {
+        this.settings.provider = 'openai';
+        this.settings.baseUrl = PROVIDER_CONFIGS.openai.defaultBaseUrl;
+        await this.saveSettings();
+      }
+    }
+
+    this.secrets = createSecretsStrategy(
+      Platform.isMobile,
+      Platform.isMobile ? this.settings.mobileDeviceKey : undefined
+    );
 
     this.registerView(CHAT_VIEW_TYPE, (leaf) => new ChatView(leaf, this));
 

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -29,16 +29,22 @@ export default class CurraintPlugin extends Plugin {
     await this.loadSettings();
 
     if (Platform.isMobile) {
+      let shouldSaveSettings = false;
+
       // Generate a device key on first mobile run - used by MobileSecretsStrategy.
       if (!this.settings.mobileDeviceKey) {
         this.settings.mobileDeviceKey = generateMobileDeviceKey();
-        await this.saveSettings();
+        shouldSaveSettings = true;
       }
       // LM Studio requires a local server, which is not reachable from mobile.
       // Reset to OpenAI if the provider was synced from a desktop vault.
       if (this.settings.provider === 'lmstudio') {
         this.settings.provider = 'openai';
         this.settings.baseUrl = PROVIDER_CONFIGS.openai.defaultBaseUrl;
+        shouldSaveSettings = true;
+      }
+
+      if (shouldSaveSettings) {
         await this.saveSettings();
       }
     }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -1,0 +1,71 @@
+import { Plugin } from 'obsidian';
+import { CurraintSettingTab } from './settings-tab';
+import { ChatView, CHAT_VIEW_TYPE } from './chat/chat-view';
+import type { PluginSettings } from './types';
+
+export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
+  provider: 'openai',
+  apiKeyEncrypted: '',
+  baseUrl: 'https://api.openai.com/v1',
+  model: 'gpt-4o-mini',
+  systemPrompt: 'You are a helpful assistant.',
+  contextMaxMessages: 40,
+  contextMaxCharacters: 24000,
+  enableSessionSaving: false,
+};
+
+export default class CurraintPlugin extends Plugin {
+  settings: PluginSettings = { ...DEFAULT_PLUGIN_SETTINGS };
+
+  async onload(): Promise<void> {
+    await this.loadSettings();
+
+    this.registerView(CHAT_VIEW_TYPE, (leaf) => new ChatView(leaf, this));
+
+    this.addRibbonIcon('message-circle', 'Open Curraint Chat', () => {
+      this.activateChatView();
+    });
+
+    this.addCommand({
+      id: 'open-chat',
+      name: 'Open chat',
+      callback: () => this.activateChatView(),
+    });
+
+    this.addCommand({
+      id: 'open-chat-with-note',
+      name: 'Open chat with current note as context',
+      callback: () => this.activateChatView({ injectNote: true }),
+    });
+
+    this.addSettingTab(new CurraintSettingTab(this.app, this));
+  }
+
+  onunload(): void {
+    this.app.workspace.detachLeavesOfType(CHAT_VIEW_TYPE);
+  }
+
+  async loadSettings(): Promise<void> {
+    this.settings = Object.assign({}, DEFAULT_PLUGIN_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings(): Promise<void> {
+    await this.saveData(this.settings);
+  }
+
+  async activateChatView(options?: { injectNote?: boolean }): Promise<void> {
+    const { workspace } = this.app;
+    let leaf = workspace.getLeavesOfType(CHAT_VIEW_TYPE)[0];
+
+    if (!leaf) {
+      leaf = workspace.getRightLeaf(false) ?? workspace.getLeaf(true);
+      await leaf.setViewState({ type: CHAT_VIEW_TYPE, active: true });
+    }
+
+    workspace.revealLeaf(leaf);
+
+    if (options?.injectNote && leaf.view instanceof ChatView) {
+      await (leaf.view as ChatView).injectCurrentNote();
+    }
+  }
+}

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -74,7 +74,10 @@ export default class CurraintPlugin extends Plugin {
   }
 
   async loadSettings(): Promise<void> {
-    this.settings = Object.assign({}, DEFAULT_PLUGIN_SETTINGS, await this.loadData());
+    this.settings = {
+      ...DEFAULT_PLUGIN_SETTINGS,
+      ...(await this.loadData()),
+    };
   }
 
   async saveSettings(): Promise<void> {
@@ -93,7 +96,7 @@ export default class CurraintPlugin extends Plugin {
     workspace.revealLeaf(leaf);
 
     if (options?.injectNote && leaf.view instanceof ChatView) {
-      await (leaf.view as ChatView).injectCurrentNote();
+      leaf.view.injectCurrentNote();
     }
   }
 }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -70,6 +70,11 @@ export default class CurraintPlugin extends Plugin {
   }
 
   onunload(): void {
+    for (const leaf of this.app.workspace.getLeavesOfType(CHAT_VIEW_TYPE)) {
+      if (leaf.view instanceof ChatView) {
+        leaf.view.destroyRegistry();
+      }
+    }
     this.app.workspace.detachLeavesOfType(CHAT_VIEW_TYPE);
   }
 

--- a/packages/obsidian-plugin/src/note-context.test.ts
+++ b/packages/obsidian-plugin/src/note-context.test.ts
@@ -15,6 +15,19 @@ describe('buildNoteContextMessage', () => {
     expect(await buildNoteContextMessage(app)).toBeNull();
   });
 
+  it('returns null when reading the active file fails', async () => {
+    const app = {
+      workspace: { getActiveFile: () => ({ basename: 'Broken Note' }) },
+      vault: {
+        read: async () => {
+          throw new Error('Read failed');
+        },
+      },
+    } as unknown as App;
+
+    expect(await buildNoteContextMessage(app)).toBeNull();
+  });
+
   it('returns null when the note is blank', async () => {
     const app = makeApp({ basename: 'My Note' }, '   \n  ');
     expect(await buildNoteContextMessage(app)).toBeNull();

--- a/packages/obsidian-plugin/src/note-context.test.ts
+++ b/packages/obsidian-plugin/src/note-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNoteContextMessage } from './note-context';
+import { buildNoteContextMessage, NOTE_CONTEXT_PREFIX } from './note-context';
 import type { App } from 'obsidian';
 
 function makeApp(file: { basename: string } | null, content: string): App {
@@ -25,6 +25,7 @@ describe('buildNoteContextMessage', () => {
     const msg = await buildNoteContextMessage(app);
     expect(msg).not.toBeNull();
     expect(msg?.role).toBe('system');
+    expect(msg?.content.startsWith(NOTE_CONTEXT_PREFIX)).toBe(true);
     expect(msg?.content).toContain('My Note');
   });
 

--- a/packages/obsidian-plugin/src/note-context.test.ts
+++ b/packages/obsidian-plugin/src/note-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildNoteContextMessage } from './note-context';
+import type { App } from 'obsidian';
+
+function makeApp(file: { basename: string } | null, content: string): App {
+  return {
+    workspace: { getActiveFile: () => file },
+    vault: { read: async () => content },
+  } as unknown as App;
+}
+
+describe('buildNoteContextMessage', () => {
+  it('returns null when no file is open', async () => {
+    const app = makeApp(null, '');
+    expect(await buildNoteContextMessage(app)).toBeNull();
+  });
+
+  it('returns null when the note is blank', async () => {
+    const app = makeApp({ basename: 'My Note' }, '   \n  ');
+    expect(await buildNoteContextMessage(app)).toBeNull();
+  });
+
+  it('returns a system message containing the note title', async () => {
+    const app = makeApp({ basename: 'My Note' }, '# Hello\nThis is my note.');
+    const msg = await buildNoteContextMessage(app);
+    expect(msg).not.toBeNull();
+    expect(msg?.role).toBe('system');
+    expect(msg?.content).toContain('My Note');
+  });
+
+  it('includes the full note content in the message', async () => {
+    const content = '# Hello\nThis is my note.';
+    const app = makeApp({ basename: 'Test' }, content);
+    const msg = await buildNoteContextMessage(app);
+    expect(msg?.content).toContain(content);
+  });
+});

--- a/packages/obsidian-plugin/src/note-context.ts
+++ b/packages/obsidian-plugin/src/note-context.ts
@@ -11,13 +11,17 @@ export async function buildNoteContextMessageForFile(
   app: App,
   file: TFile
 ): Promise<ChatMessage | null> {
-  const content = await app.vault.read(file);
-  if (!content.trim()) return null;
+  try {
+    const content = await app.vault.read(file);
+    if (!content.trim()) return null;
 
-  return {
-    role: 'system',
-    content: `${NOTE_CONTEXT_PREFIX} for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
-  };
+    return {
+      role: 'system',
+      content: `${NOTE_CONTEXT_PREFIX} for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/obsidian-plugin/src/note-context.ts
+++ b/packages/obsidian-plugin/src/note-context.ts
@@ -1,6 +1,8 @@
 import type { App, TFile } from 'obsidian';
 import type { ChatMessage } from '@curraint/core';
 
+export const NOTE_CONTEXT_PREFIX = 'The user has shared the following note';
+
 /**
  * Builds a system ChatMessage for the given note file. Returns null when
  * the file content is blank.
@@ -14,7 +16,7 @@ export async function buildNoteContextMessageForFile(
 
   return {
     role: 'system',
-    content: `The user has shared the following note for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
+    content: `${NOTE_CONTEXT_PREFIX} for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
   };
 }
 

--- a/packages/obsidian-plugin/src/note-context.ts
+++ b/packages/obsidian-plugin/src/note-context.ts
@@ -1,0 +1,19 @@
+import type { App } from 'obsidian';
+import type { ChatMessage } from '@curraint/core';
+
+/**
+ * Reads the currently active note and returns it as a system ChatMessage
+ * that can be prepended to the conversation. Returns null when no note is open.
+ */
+export async function buildNoteContextMessage(app: App): Promise<ChatMessage | null> {
+  const file = app.workspace.getActiveFile();
+  if (!file) return null;
+
+  const content = await app.vault.read(file);
+  if (!content.trim()) return null;
+
+  return {
+    role: 'system',
+    content: `The user has shared the following note for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
+  };
+}

--- a/packages/obsidian-plugin/src/note-context.ts
+++ b/packages/obsidian-plugin/src/note-context.ts
@@ -1,5 +1,22 @@
-import type { App } from 'obsidian';
+import type { App, TFile } from 'obsidian';
 import type { ChatMessage } from '@curraint/core';
+
+/**
+ * Builds a system ChatMessage for the given note file. Returns null when
+ * the file content is blank.
+ */
+export async function buildNoteContextMessageForFile(
+  app: App,
+  file: TFile
+): Promise<ChatMessage | null> {
+  const content = await app.vault.read(file);
+  if (!content.trim()) return null;
+
+  return {
+    role: 'system',
+    content: `The user has shared the following note for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
+  };
+}
 
 /**
  * Reads the currently active note and returns it as a system ChatMessage
@@ -8,12 +25,5 @@ import type { ChatMessage } from '@curraint/core';
 export async function buildNoteContextMessage(app: App): Promise<ChatMessage | null> {
   const file = app.workspace.getActiveFile();
   if (!file) return null;
-
-  const content = await app.vault.read(file);
-  if (!content.trim()) return null;
-
-  return {
-    role: 'system',
-    content: `The user has shared the following note for context. Its title is "${file.basename}".\n\n---\n\n${content}`,
-  };
+  return buildNoteContextMessageForFile(app, file);
 }

--- a/packages/obsidian-plugin/src/secrets.test.ts
+++ b/packages/obsidian-plugin/src/secrets.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { encryptApiKey, decryptApiKey } from './secrets';
+
+describe('encryptApiKey / decryptApiKey', () => {
+  it('round-trips a non-empty key', () => {
+    const plaintext = 'sk-test-api-key-12345';
+    const encrypted = encryptApiKey(plaintext);
+    expect(encrypted).not.toBe(plaintext);
+    expect(decryptApiKey(encrypted)).toBe(plaintext);
+  });
+
+  it('produces different ciphertexts for the same plaintext (random IV)', () => {
+    const key = 'my-key';
+    expect(encryptApiKey(key)).not.toBe(encryptApiKey(key));
+  });
+
+  it('returns empty string for invalid ciphertext', () => {
+    expect(decryptApiKey('not-valid-json')).toBe('');
+    expect(decryptApiKey('{}')).toBe('');
+  });
+
+  it('round-trips an empty string', () => {
+    expect(decryptApiKey(encryptApiKey(''))).toBe('');
+  });
+});

--- a/packages/obsidian-plugin/src/secrets.test.ts
+++ b/packages/obsidian-plugin/src/secrets.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   DesktopSecretsStrategy,
   InvalidMobileDeviceKeyError,
@@ -81,6 +81,22 @@ describe('MobileSecretsStrategy', () => {
     expect(() => new MobileSecretsStrategy(wrongLengthKey)).toThrow(
       'Mobile device key must decode to exactly 32 bytes'
     );
+  });
+
+  it('defers CryptoKey import until first use', async () => {
+    const importKeySpy = vi.spyOn(globalThis.crypto.subtle, 'importKey');
+
+    try {
+      const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+
+      expect(importKeySpy).not.toHaveBeenCalled();
+
+      await strategy.encrypt('secret-value');
+
+      expect(importKeySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      importKeySpy.mockRestore();
+    }
   });
 
   it('rejects import failures with a typed error', async () => {

--- a/packages/obsidian-plugin/src/secrets.test.ts
+++ b/packages/obsidian-plugin/src/secrets.test.ts
@@ -1,25 +1,65 @@
 import { describe, it, expect } from 'vitest';
-import { encryptApiKey, decryptApiKey } from './secrets';
+import {
+  DesktopSecretsStrategy,
+  MobileSecretsStrategy,
+  generateMobileDeviceKey,
+} from './secrets';
 
-describe('encryptApiKey / decryptApiKey', () => {
-  it('round-trips a non-empty key', () => {
-    const plaintext = 'sk-test-api-key-12345';
-    const encrypted = encryptApiKey(plaintext);
-    expect(encrypted).not.toBe(plaintext);
-    expect(decryptApiKey(encrypted)).toBe(plaintext);
+describe('DesktopSecretsStrategy', () => {
+  it('round-trips a non-empty key', async () => {
+    const strategy = new DesktopSecretsStrategy();
+    const encrypted = await strategy.encrypt('sk-test-api-key-12345');
+    expect(encrypted).not.toBe('sk-test-api-key-12345');
+    expect(await strategy.decrypt(encrypted)).toBe('sk-test-api-key-12345');
   });
 
-  it('produces different ciphertexts for the same plaintext (random IV)', () => {
+  it('produces different ciphertexts for the same plaintext (random IV)', async () => {
+    const strategy = new DesktopSecretsStrategy();
     const key = 'my-key';
-    expect(encryptApiKey(key)).not.toBe(encryptApiKey(key));
+    expect(await strategy.encrypt(key)).not.toBe(await strategy.encrypt(key));
   });
 
-  it('returns empty string for invalid ciphertext', () => {
-    expect(decryptApiKey('not-valid-json')).toBe('');
-    expect(decryptApiKey('{}')).toBe('');
+  it('returns empty string for invalid ciphertext', async () => {
+    const strategy = new DesktopSecretsStrategy();
+    expect(await strategy.decrypt('not-valid-json')).toBe('');
+    expect(await strategy.decrypt('{}')).toBe('');
   });
 
-  it('round-trips an empty string', () => {
-    expect(decryptApiKey(encryptApiKey(''))).toBe('');
+  it('round-trips an empty string', async () => {
+    const strategy = new DesktopSecretsStrategy();
+    expect(await strategy.decrypt(await strategy.encrypt(''))).toBe('');
+  });
+});
+
+describe('MobileSecretsStrategy', () => {
+  it('round-trips a non-empty key', async () => {
+    const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+    const encrypted = await strategy.encrypt('sk-test-api-key-12345');
+    expect(encrypted).not.toBe('sk-test-api-key-12345');
+    expect(await strategy.decrypt(encrypted)).toBe('sk-test-api-key-12345');
+  });
+
+  it('produces different ciphertexts for the same plaintext (random IV)', async () => {
+    const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+    const key = 'my-key';
+    expect(await strategy.encrypt(key)).not.toBe(await strategy.encrypt(key));
+  });
+
+  it('returns empty string for invalid ciphertext', async () => {
+    const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+    expect(await strategy.decrypt('not-valid-json')).toBe('');
+    expect(await strategy.decrypt('{}')).toBe('');
+  });
+
+  it('round-trips an empty string', async () => {
+    const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+    expect(await strategy.decrypt(await strategy.encrypt(''))).toBe('');
+  });
+
+  it('cannot decrypt ciphertext from a different device key', async () => {
+    const strategy1 = new MobileSecretsStrategy(generateMobileDeviceKey());
+    const strategy2 = new MobileSecretsStrategy(generateMobileDeviceKey());
+    const encrypted = await strategy1.encrypt('secret-value');
+    expect(await strategy2.decrypt(encrypted)).toBe('');
   });
 });

--- a/packages/obsidian-plugin/src/secrets.test.ts
+++ b/packages/obsidian-plugin/src/secrets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   DesktopSecretsStrategy,
+  InvalidMobileDeviceKeyError,
   MobileSecretsStrategy,
   generateMobileDeviceKey,
 } from './secrets';
@@ -61,5 +62,54 @@ describe('MobileSecretsStrategy', () => {
     const strategy2 = new MobileSecretsStrategy(generateMobileDeviceKey());
     const encrypted = await strategy1.encrypt('secret-value');
     expect(await strategy2.decrypt(encrypted)).toBe('');
+  });
+
+  it('rejects malformed base64 device keys with a typed error', async () => {
+    expect(() => new MobileSecretsStrategy('not base64!!!')).toThrowError(
+      InvalidMobileDeviceKeyError
+    );
+    expect(() => new MobileSecretsStrategy('not base64!!!')).toThrow(
+      'Mobile device key must be a valid base64-encoded 32-byte AES key'
+    );
+  });
+
+  it('rejects device keys that decode to the wrong length', async () => {
+    const wrongLengthKey = btoa(String.fromCharCode(...Array.from(new Uint8Array(33))));
+    expect(() => new MobileSecretsStrategy(wrongLengthKey)).toThrowError(
+      InvalidMobileDeviceKeyError
+    );
+    expect(() => new MobileSecretsStrategy(wrongLengthKey)).toThrow(
+      'Mobile device key must decode to exactly 32 bytes'
+    );
+  });
+
+  it('rejects import failures with a typed error', async () => {
+    const originalSubtle = globalThis.crypto.subtle;
+    const importFailure = new DOMException('import failed', 'OperationError');
+
+    Object.defineProperty(globalThis.crypto, 'subtle', {
+      configurable: true,
+      value: {
+        ...originalSubtle,
+        importKey: async () => {
+          throw importFailure;
+        },
+      } satisfies SubtleCrypto,
+    });
+
+    try {
+      const strategy = new MobileSecretsStrategy(generateMobileDeviceKey());
+      await expect(strategy.encrypt('secret-value')).rejects.toBeInstanceOf(
+        InvalidMobileDeviceKeyError
+      );
+      await expect(strategy.encrypt('secret-value')).rejects.toThrow(
+        'Failed to import mobile device key for AES-GCM encryption'
+      );
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'subtle', {
+        configurable: true,
+        value: originalSubtle,
+      });
+    }
   });
 });

--- a/packages/obsidian-plugin/src/secrets.ts
+++ b/packages/obsidian-plugin/src/secrets.ts
@@ -1,0 +1,52 @@
+import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from 'crypto';
+import os from 'os';
+
+// AES-256-GCM encryption with a PBKDF2 key derived from machine identity.
+// The encrypted blob is stored in plugin data.json. It is machine-bound:
+// it cannot be decrypted on a different machine.
+// This mirrors the approach used in @curraint/core secrets for consistency.
+const ALGORITHM = 'aes-256-gcm';
+const IV_LEN = 12;
+const KEY_LEN = 32;
+const KDF_SALT = 'curraint-obsidian-v1';
+const KDF_ITERATIONS = 100_000;
+
+type EncryptedBlob = { iv: string; tag: string; data: string };
+
+let _cachedKey: Buffer | undefined;
+
+function derivedKey(): Buffer {
+  if (_cachedKey) return _cachedKey;
+  const identity = `${os.hostname()}:${os.userInfo().username}`;
+  _cachedKey = pbkdf2Sync(identity, KDF_SALT, KDF_ITERATIONS, KEY_LEN, 'sha256');
+  return _cachedKey;
+}
+
+export function encryptApiKey(plaintext: string): string {
+  const key = derivedKey();
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const blob: EncryptedBlob = {
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    data: encrypted.toString('base64'),
+  };
+  return JSON.stringify(blob);
+}
+
+export function decryptApiKey(stored: string): string {
+  try {
+    const blob = JSON.parse(stored) as EncryptedBlob;
+    if (!blob.iv || !blob.tag || !blob.data) return '';
+    const key = derivedKey();
+    const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(blob.iv, 'base64'));
+    decipher.setAuthTag(Buffer.from(blob.tag, 'base64'));
+    return Buffer.concat([
+      decipher.update(Buffer.from(blob.data, 'base64')),
+      decipher.final(),
+    ]).toString('utf8');
+  } catch {
+    return '';
+  }
+}

--- a/packages/obsidian-plugin/src/secrets.ts
+++ b/packages/obsidian-plugin/src/secrets.ts
@@ -93,11 +93,11 @@ export class DesktopSecretsStrategy implements SecretsStrategy {
 type MobileBlob = { iv: string; data: string };
 
 export class MobileSecretsStrategy implements SecretsStrategy {
-  private readonly keyPromise: Promise<CryptoKey>;
+  private readonly rawKey: Uint8Array;
+  private keyPromise: Promise<CryptoKey> | null = null;
 
   constructor(deviceKey: string) {
-    this.decodeDeviceKey(deviceKey);
-    this.keyPromise = this.importKey(deviceKey);
+    this.rawKey = this.decodeDeviceKey(deviceKey);
   }
 
   private decodeDeviceKey(deviceKey: string): Uint8Array {
@@ -129,15 +129,11 @@ export class MobileSecretsStrategy implements SecretsStrategy {
     }
   }
 
-  private async importKey(deviceKey: string): Promise<CryptoKey> {
-    const keyBytes = this.decodeDeviceKey(deviceKey);
-    const rawKey = new Uint8Array(keyBytes.length);
-    rawKey.set(keyBytes);
-
+  private async importKey(): Promise<CryptoKey> {
     try {
       return await globalThis.crypto.subtle.importKey(
         'raw',
-        rawKey,
+        this.rawKey,
         { name: 'AES-GCM' },
         false,
         ['encrypt', 'decrypt']
@@ -154,8 +150,16 @@ export class MobileSecretsStrategy implements SecretsStrategy {
     }
   }
 
+  private getKey(): Promise<CryptoKey> {
+    if (!this.keyPromise) {
+      this.keyPromise = this.importKey();
+    }
+
+    return this.keyPromise;
+  }
+
   async encrypt(plaintext: string): Promise<string> {
-    const key = await this.keyPromise;
+    const key = await this.getKey();
     const iv = new Uint8Array(IV_LEN);
     globalThis.crypto.getRandomValues(iv);
     const ciphertext = await globalThis.crypto.subtle.encrypt(
@@ -174,7 +178,7 @@ export class MobileSecretsStrategy implements SecretsStrategy {
     try {
       const blob = JSON.parse(stored) as MobileBlob;
       if (!blob.iv || !blob.data) return '';
-      const key = await this.keyPromise;
+      const key = await this.getKey();
       const iv = Uint8Array.from(atob(blob.iv), (c) => c.charCodeAt(0));
       const ciphertext = Uint8Array.from(atob(blob.data), (c) => c.charCodeAt(0));
       const plaintext = await globalThis.crypto.subtle.decrypt(

--- a/packages/obsidian-plugin/src/secrets.ts
+++ b/packages/obsidian-plugin/src/secrets.ts
@@ -8,6 +8,18 @@ export interface SecretsStrategy {
 
 const IV_LEN = 12;
 const KEY_LEN = 32;
+const MOBILE_DEVICE_KEY_BASE64_LEN = 44;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export class InvalidMobileDeviceKeyError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = 'InvalidMobileDeviceKeyError';
+    this.cause = options?.cause;
+  }
+}
 
 // --- Desktop strategy (Node.js crypto, machine-bound) -----------------------
 // Uses AES-256-GCM with a PBKDF2 key derived from the machine's hostname and
@@ -21,7 +33,8 @@ const KEY_LEN = 32;
 type DesktopBlob = { iv: string; tag: string; data: string };
 
 const KDF_SALT = 'curraint-obsidian-v1';
-const KDF_ITERATIONS = 100_000;
+// Keep PBKDF2 cost aligned with current OWASP guidance for password-based KDFs.
+const KDF_ITERATIONS = 600_000;
 
 export class DesktopSecretsStrategy implements SecretsStrategy {
   private readonly _key: Buffer;
@@ -83,18 +96,62 @@ export class MobileSecretsStrategy implements SecretsStrategy {
   private readonly keyPromise: Promise<CryptoKey>;
 
   constructor(deviceKey: string) {
+    this.decodeDeviceKey(deviceKey);
     this.keyPromise = this.importKey(deviceKey);
   }
 
+  private decodeDeviceKey(deviceKey: string): Uint8Array {
+    if (!BASE64_PATTERN.test(deviceKey) || deviceKey.length !== MOBILE_DEVICE_KEY_BASE64_LEN) {
+      throw new InvalidMobileDeviceKeyError(
+        'Mobile device key must be a valid base64-encoded 32-byte AES key'
+      );
+    }
+
+    try {
+      const keyBytes = Uint8Array.from(atob(deviceKey), (c) => c.charCodeAt(0));
+
+      if (keyBytes.length !== KEY_LEN) {
+        throw new InvalidMobileDeviceKeyError(
+          'Mobile device key must decode to exactly 32 bytes'
+        );
+      }
+
+      return keyBytes;
+    } catch (error) {
+      if (error instanceof InvalidMobileDeviceKeyError) {
+        throw error;
+      }
+
+      throw new InvalidMobileDeviceKeyError(
+        'Mobile device key must be a valid base64-encoded 32-byte AES key',
+        { cause: error }
+      );
+    }
+  }
+
   private async importKey(deviceKey: string): Promise<CryptoKey> {
-    const keyBytes = Uint8Array.from(atob(deviceKey), (c) => c.charCodeAt(0));
-    return globalThis.crypto.subtle.importKey(
-      'raw',
-      keyBytes,
-      { name: 'AES-GCM' },
-      false,
-      ['encrypt', 'decrypt']
-    );
+    const keyBytes = this.decodeDeviceKey(deviceKey);
+    const rawKey = new Uint8Array(keyBytes.length);
+    rawKey.set(keyBytes);
+
+    try {
+      return await globalThis.crypto.subtle.importKey(
+        'raw',
+        rawKey,
+        { name: 'AES-GCM' },
+        false,
+        ['encrypt', 'decrypt']
+      );
+    } catch (error) {
+      if (error instanceof InvalidMobileDeviceKeyError) {
+        throw error;
+      }
+
+      throw new InvalidMobileDeviceKeyError(
+        'Failed to import mobile device key for AES-GCM encryption',
+        { cause: error }
+      );
+    }
   }
 
   async encrypt(plaintext: string): Promise<string> {

--- a/packages/obsidian-plugin/src/secrets.ts
+++ b/packages/obsidian-plugin/src/secrets.ts
@@ -1,52 +1,152 @@
-import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from 'crypto';
-import os from 'os';
+// Platform-agnostic strategy interface for API key encryption.
+export interface SecretsStrategy {
+  encrypt(plaintext: string): Promise<string>;
+  decrypt(stored: string): Promise<string>;
+}
 
-// AES-256-GCM encryption with a PBKDF2 key derived from machine identity.
-// The encrypted blob is stored in plugin data.json. It is machine-bound:
-// it cannot be decrypted on a different machine.
-// This mirrors the approach used in @curraint/core secrets for consistency.
-const ALGORITHM = 'aes-256-gcm';
+// --- Shared constants -------------------------------------------------------
+
 const IV_LEN = 12;
 const KEY_LEN = 32;
+
+// --- Desktop strategy (Node.js crypto, machine-bound) -----------------------
+// Uses AES-256-GCM with a PBKDF2 key derived from the machine's hostname and
+// username. The encrypted blob cannot be decrypted on a different machine.
+//
+// Node.js built-ins are required inline (not at the top of the module) so
+// that esbuild does not emit top-level require('crypto') / require('os') calls
+// in the bundle. Those top-level calls would throw on mobile where Node.js
+// built-ins are unavailable, even if the desktop strategy is never used.
+
+type DesktopBlob = { iv: string; tag: string; data: string };
+
 const KDF_SALT = 'curraint-obsidian-v1';
 const KDF_ITERATIONS = 100_000;
 
-type EncryptedBlob = { iv: string; tag: string; data: string };
+export class DesktopSecretsStrategy implements SecretsStrategy {
+  private readonly _key: Buffer;
 
-let _cachedKey: Buffer | undefined;
-
-function derivedKey(): Buffer {
-  if (_cachedKey) return _cachedKey;
-  const identity = `${os.hostname()}:${os.userInfo().username}`;
-  _cachedKey = pbkdf2Sync(identity, KDF_SALT, KDF_ITERATIONS, KEY_LEN, 'sha256');
-  return _cachedKey;
-}
-
-export function encryptApiKey(plaintext: string): string {
-  const key = derivedKey();
-  const iv = randomBytes(IV_LEN);
-  const cipher = createCipheriv(ALGORITHM, key, iv);
-  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const blob: EncryptedBlob = {
-    iv: iv.toString('base64'),
-    tag: cipher.getAuthTag().toString('base64'),
-    data: encrypted.toString('base64'),
-  };
-  return JSON.stringify(blob);
-}
-
-export function decryptApiKey(stored: string): string {
-  try {
-    const blob = JSON.parse(stored) as EncryptedBlob;
-    if (!blob.iv || !blob.tag || !blob.data) return '';
-    const key = derivedKey();
-    const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(blob.iv, 'base64'));
-    decipher.setAuthTag(Buffer.from(blob.tag, 'base64'));
-    return Buffer.concat([
-      decipher.update(Buffer.from(blob.data, 'base64')),
-      decipher.final(),
-    ]).toString('utf8');
-  } catch {
-    return '';
+  constructor() {
+    // Inline require so esbuild does not hoist Node.js built-in imports to the
+    // top of the bundle, which would throw on mobile where Node.js is absent.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { pbkdf2Sync } = require('crypto') as typeof import('crypto');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const os = require('os') as typeof import('os');
+    const identity = `${os.hostname()}:${os.userInfo().username}`;
+    this._key = pbkdf2Sync(identity, KDF_SALT, KDF_ITERATIONS, KEY_LEN, 'sha256');
   }
+
+  async encrypt(plaintext: string): Promise<string> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createCipheriv, randomBytes } = require('crypto') as typeof import('crypto');
+    const key = this._key;
+    const iv = randomBytes(IV_LEN);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const blob: DesktopBlob = {
+      iv: iv.toString('base64'),
+      tag: cipher.getAuthTag().toString('base64'),
+      data: encrypted.toString('base64'),
+    };
+    return JSON.stringify(blob);
+  }
+
+  async decrypt(stored: string): Promise<string> {
+    try {
+      const blob = JSON.parse(stored) as DesktopBlob;
+      if (!blob.iv || !blob.tag || !blob.data) return '';
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { createDecipheriv } = require('crypto') as typeof import('crypto');
+      const key = this._key;
+      const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(blob.iv, 'base64'));
+      decipher.setAuthTag(Buffer.from(blob.tag, 'base64'));
+      return Buffer.concat([
+        decipher.update(Buffer.from(blob.data, 'base64')),
+        decipher.final(),
+      ]).toString('utf8');
+    } catch {
+      return '';
+    }
+  }
+}
+
+// --- Mobile strategy (Web Crypto API) ---------------------------------------
+// Uses AES-256-GCM via the standard Web Crypto API, which is available in
+// Obsidian's mobile runtime (iOS / Android). The key is a random 32-byte
+// device key generated on first run and persisted in plugin data.
+// Web Crypto AES-GCM output already appends the 16-byte authentication tag.
+
+type MobileBlob = { iv: string; data: string };
+
+export class MobileSecretsStrategy implements SecretsStrategy {
+  private readonly keyPromise: Promise<CryptoKey>;
+
+  constructor(deviceKey: string) {
+    this.keyPromise = this.importKey(deviceKey);
+  }
+
+  private async importKey(deviceKey: string): Promise<CryptoKey> {
+    const keyBytes = Uint8Array.from(atob(deviceKey), (c) => c.charCodeAt(0));
+    return globalThis.crypto.subtle.importKey(
+      'raw',
+      keyBytes,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  async encrypt(plaintext: string): Promise<string> {
+    const key = await this.keyPromise;
+    const iv = new Uint8Array(IV_LEN);
+    globalThis.crypto.getRandomValues(iv);
+    const ciphertext = await globalThis.crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      new TextEncoder().encode(plaintext)
+    );
+    const blob: MobileBlob = {
+      iv: btoa(String.fromCharCode(...Array.from(iv))),
+      data: btoa(String.fromCharCode(...Array.from(new Uint8Array(ciphertext)))),
+    };
+    return JSON.stringify(blob);
+  }
+
+  async decrypt(stored: string): Promise<string> {
+    try {
+      const blob = JSON.parse(stored) as MobileBlob;
+      if (!blob.iv || !blob.data) return '';
+      const key = await this.keyPromise;
+      const iv = Uint8Array.from(atob(blob.iv), (c) => c.charCodeAt(0));
+      const ciphertext = Uint8Array.from(atob(blob.data), (c) => c.charCodeAt(0));
+      const plaintext = await globalThis.crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        ciphertext
+      );
+      return new TextDecoder().decode(plaintext);
+    } catch {
+      return '';
+    }
+  }
+}
+
+// --- Factory + device key helper --------------------------------------------
+
+// Generates a cryptographically random 32-byte key as a base64 string.
+// Uses globalThis.crypto.getRandomValues which is available on both desktop
+// (Node.js 15+) and mobile (Web Crypto API standard).
+export function generateMobileDeviceKey(): string {
+  const bytes = new Uint8Array(KEY_LEN);
+  globalThis.crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...Array.from(bytes)));
+}
+
+export function createSecretsStrategy(isMobile: boolean, deviceKey?: string): SecretsStrategy {
+  if (isMobile) {
+    if (!deviceKey) throw new Error('Mobile device key is required but was not provided');
+    return new MobileSecretsStrategy(deviceKey);
+  }
+  return new DesktopSecretsStrategy();
 }

--- a/packages/obsidian-plugin/src/settings-tab.ts
+++ b/packages/obsidian-plugin/src/settings-tab.ts
@@ -1,7 +1,6 @@
-import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { App, Platform, PluginSettingTab, Setting, Notice } from 'obsidian';
 import { PROVIDER_OPTIONS, testConnection } from '@curraint/core';
 import type CurraintPlugin from './main';
-import { encryptApiKey, decryptApiKey } from './secrets';
 import { testLmStudioConnection } from './transport';
 
 export class CurraintSettingTab extends PluginSettingTab {
@@ -12,15 +11,38 @@ export class CurraintSettingTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
-  display(): void {
+  async display(): Promise<void> {
     const { containerEl } = this;
     containerEl.empty();
 
-    new Setting(containerEl)
+    // Pre-decrypt before rendering so the API key field can be populated
+    // synchronously inside the Obsidian Settings builder callbacks.
+    const decryptedApiKey = this.plugin.settings.apiKeyEncrypted
+      ? await this.plugin.secrets.decrypt(this.plugin.settings.apiKeyEncrypted)
+      : '';
+
+    // On mobile, local providers that require a server on the same machine
+    // are not reachable. Filter them out so users cannot accidentally select
+    // them and get confusing connection errors.
+    const providerOptions = Platform.isMobile
+      ? PROVIDER_OPTIONS.filter((p) => p.id !== 'lmstudio')
+      : PROVIDER_OPTIONS;
+
+    this.renderProviderSection(containerEl, providerOptions, decryptedApiKey);
+    this.renderContextLimitsSection(containerEl);
+    this.renderSessionsSection(containerEl);
+  }
+
+  private renderProviderSection(
+    el: HTMLElement,
+    providerOptions: typeof PROVIDER_OPTIONS,
+    decryptedApiKey: string,
+  ): void {
+    new Setting(el)
       .setName('Provider')
       .setDesc('AI provider to use for chat completions.')
       .addDropdown((drop) => {
-        for (const p of PROVIDER_OPTIONS) {
+        for (const p of providerOptions) {
           drop.addOption(p.id, p.label);
         }
         drop.setValue(this.plugin.settings.provider);
@@ -40,7 +62,7 @@ export class CurraintSettingTab extends PluginSettingTab {
     );
 
     if (selectedProvider?.requiresBaseUrl) {
-      new Setting(containerEl)
+      new Setting(el)
         .setName('Base URL')
         .setDesc('API base URL for the provider.')
         .addText((text) =>
@@ -54,7 +76,7 @@ export class CurraintSettingTab extends PluginSettingTab {
         );
     }
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('Model')
       .setDesc('Model name to use for completions.')
       .addText((text) =>
@@ -68,30 +90,26 @@ export class CurraintSettingTab extends PluginSettingTab {
       );
 
     if (selectedProvider?.requiresApiKey) {
-      new Setting(containerEl)
+      new Setting(el)
         .setName('API key')
         .setDesc(
-          'Your API key. Stored encrypted using your OS credentials — never synced in plain text.'
+          'Your API key. Stored encrypted - never synced in plain text.'
         )
         .addText((text) => {
           text.inputEl.type = 'password';
           text
             .setPlaceholder('sk-...')
-            .setValue(
-              this.plugin.settings.apiKeyEncrypted
-                ? decryptApiKey(this.plugin.settings.apiKeyEncrypted)
-                : ''
-            )
+            .setValue(decryptedApiKey)
             .onChange(async (value) => {
               this.plugin.settings.apiKeyEncrypted = value
-                ? encryptApiKey(value.trim())
+                ? await this.plugin.secrets.encrypt(value.trim())
                 : '';
               await this.plugin.saveSettings();
             });
         });
     }
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('System prompt')
       .setDesc('Default system prompt prepended to every conversation.')
       .addTextArea((text) =>
@@ -102,10 +120,12 @@ export class CurraintSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+  }
 
-    new Setting(containerEl).setName('Context limits').setHeading();
+  private renderContextLimitsSection(el: HTMLElement): void {
+    new Setting(el).setName('Context limits').setHeading();
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('Max messages')
       .setDesc('Maximum number of messages kept in context (4-120).')
       .addText((text) =>
@@ -120,7 +140,7 @@ export class CurraintSettingTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('Max characters')
       .setDesc('Maximum total characters kept in context (4000-200000).')
       .addText((text) =>
@@ -134,10 +154,12 @@ export class CurraintSettingTab extends PluginSettingTab {
             }
           })
       );
+  }
 
-    new Setting(containerEl).setName('Sessions').setHeading();
+  private renderSessionsSection(el: HTMLElement): void {
+    new Setting(el).setName('Sessions').setHeading();
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('Save sessions')
       .setDesc(
         'Persist conversations so you can resume them later. ' +
@@ -152,7 +174,7 @@ export class CurraintSettingTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl)
+    new Setting(el)
       .setName('Test connection')
       .setDesc('Verify the current provider settings can reach the API.')
       .addButton((btn) =>
@@ -161,7 +183,7 @@ export class CurraintSettingTab extends PluginSettingTab {
           btn.setButtonText('Testing...');
           try {
             const apiKey = this.plugin.settings.apiKeyEncrypted
-              ? decryptApiKey(this.plugin.settings.apiKeyEncrypted)
+              ? await this.plugin.secrets.decrypt(this.plugin.settings.apiKeyEncrypted)
               : '';
             const endpointSettings = {
               provider: this.plugin.settings.provider,
@@ -173,9 +195,10 @@ export class CurraintSettingTab extends PluginSettingTab {
               contextMaxCharacters: this.plugin.settings.contextMaxCharacters,
               enableSessionSaving: this.plugin.settings.enableSessionSaving,
             };
-            const message = this.plugin.settings.provider === 'lmstudio'
-              ? await testLmStudioConnection(endpointSettings)
-              : await testConnection(endpointSettings);
+            const message =
+              this.plugin.settings.provider === 'lmstudio' && !Platform.isMobile
+                ? await testLmStudioConnection(endpointSettings)
+                : await testConnection(endpointSettings);
             new Notice(message);
           } catch (err) {
             new Notice(`Connection error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/obsidian-plugin/src/settings-tab.ts
+++ b/packages/obsidian-plugin/src/settings-tab.ts
@@ -1,0 +1,189 @@
+import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { PROVIDER_OPTIONS, testConnection } from '@curraint/core';
+import type CurraintPlugin from './main';
+import { encryptApiKey, decryptApiKey } from './secrets';
+import { testLmStudioConnection } from './transport';
+
+export class CurraintSettingTab extends PluginSettingTab {
+  plugin: CurraintPlugin;
+
+  constructor(app: App, plugin: CurraintPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Provider')
+      .setDesc('AI provider to use for chat completions.')
+      .addDropdown((drop) => {
+        for (const p of PROVIDER_OPTIONS) {
+          drop.addOption(p.id, p.label);
+        }
+        drop.setValue(this.plugin.settings.provider);
+        drop.onChange(async (value) => {
+          const newProvider = value as typeof this.plugin.settings.provider;
+          const config = PROVIDER_OPTIONS.find((p) => p.id === newProvider);
+          this.plugin.settings.provider = newProvider;
+          this.plugin.settings.baseUrl = config?.defaultBaseUrl ?? '';
+          this.plugin.settings.model = config?.defaultModel ?? '';
+          await this.plugin.saveSettings();
+          this.display();
+        });
+      });
+
+    const selectedProvider = PROVIDER_OPTIONS.find(
+      (p) => p.id === this.plugin.settings.provider
+    );
+
+    if (selectedProvider?.requiresBaseUrl) {
+      new Setting(containerEl)
+        .setName('Base URL')
+        .setDesc('API base URL for the provider.')
+        .addText((text) =>
+          text
+            .setPlaceholder(selectedProvider.defaultBaseUrl)
+            .setValue(this.plugin.settings.baseUrl)
+            .onChange(async (value) => {
+              this.plugin.settings.baseUrl = value.trim();
+              await this.plugin.saveSettings();
+            })
+        );
+    }
+
+    new Setting(containerEl)
+      .setName('Model')
+      .setDesc('Model name to use for completions.')
+      .addText((text) =>
+        text
+          .setPlaceholder(selectedProvider?.defaultModel ?? 'gpt-4o-mini')
+          .setValue(this.plugin.settings.model)
+          .onChange(async (value) => {
+            this.plugin.settings.model = value.trim();
+            await this.plugin.saveSettings();
+          })
+      );
+
+    if (selectedProvider?.requiresApiKey) {
+      new Setting(containerEl)
+        .setName('API key')
+        .setDesc(
+          'Your API key. Stored encrypted using your OS credentials — never synced in plain text.'
+        )
+        .addText((text) => {
+          text.inputEl.type = 'password';
+          text
+            .setPlaceholder('sk-...')
+            .setValue(
+              this.plugin.settings.apiKeyEncrypted
+                ? decryptApiKey(this.plugin.settings.apiKeyEncrypted)
+                : ''
+            )
+            .onChange(async (value) => {
+              this.plugin.settings.apiKeyEncrypted = value
+                ? encryptApiKey(value.trim())
+                : '';
+              await this.plugin.saveSettings();
+            });
+        });
+    }
+
+    new Setting(containerEl)
+      .setName('System prompt')
+      .setDesc('Default system prompt prepended to every conversation.')
+      .addTextArea((text) =>
+        text
+          .setValue(this.plugin.settings.systemPrompt)
+          .onChange(async (value) => {
+            this.plugin.settings.systemPrompt = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl).setName('Context limits').setHeading();
+
+    new Setting(containerEl)
+      .setName('Max messages')
+      .setDesc('Maximum number of messages kept in context (4-120).')
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.contextMaxMessages))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num >= 4 && num <= 120) {
+              this.plugin.settings.contextMaxMessages = num;
+              await this.plugin.saveSettings();
+            }
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Max characters')
+      .setDesc('Maximum total characters kept in context (4000-200000).')
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.contextMaxCharacters))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num >= 4000 && num <= 200000) {
+              this.plugin.settings.contextMaxCharacters = num;
+              await this.plugin.saveSettings();
+            }
+          })
+      );
+
+    new Setting(containerEl).setName('Sessions').setHeading();
+
+    new Setting(containerEl)
+      .setName('Save sessions')
+      .setDesc(
+        'Persist conversations so you can resume them later. ' +
+        'Sessions are stored in the same location as the CLI and desktop app.'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableSessionSaving)
+          .onChange(async (value) => {
+            this.plugin.settings.enableSessionSaving = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Test connection')
+      .setDesc('Verify the current provider settings can reach the API.')
+      .addButton((btn) =>
+        btn.setButtonText('Test').onClick(async () => {
+          btn.setDisabled(true);
+          btn.setButtonText('Testing...');
+          try {
+            const apiKey = this.plugin.settings.apiKeyEncrypted
+              ? decryptApiKey(this.plugin.settings.apiKeyEncrypted)
+              : '';
+            const endpointSettings = {
+              provider: this.plugin.settings.provider,
+              apiKey,
+              baseUrl: this.plugin.settings.baseUrl,
+              model: this.plugin.settings.model,
+              systemPrompt: this.plugin.settings.systemPrompt,
+              contextMaxMessages: this.plugin.settings.contextMaxMessages,
+              contextMaxCharacters: this.plugin.settings.contextMaxCharacters,
+              enableSessionSaving: this.plugin.settings.enableSessionSaving,
+            };
+            const message = this.plugin.settings.provider === 'lmstudio'
+              ? await testLmStudioConnection(endpointSettings)
+              : await testConnection(endpointSettings);
+            new Notice(message);
+          } catch (err) {
+            new Notice(`Connection error: ${err instanceof Error ? err.message : String(err)}`);
+          } finally {
+            btn.setDisabled(false);
+            btn.setButtonText('Test');
+          }
+        })
+      );
+  }
+}

--- a/packages/obsidian-plugin/src/settings-tab.ts
+++ b/packages/obsidian-plugin/src/settings-tab.ts
@@ -5,6 +5,7 @@ import { testLmStudioConnection } from './transport';
 
 export class CurraintSettingTab extends PluginSettingTab {
   plugin: CurraintPlugin;
+  private apiKeyRequestId = 0;
 
   constructor(app: App, plugin: CurraintPlugin) {
     super(app, plugin);
@@ -17,9 +18,14 @@ export class CurraintSettingTab extends PluginSettingTab {
 
     // Pre-decrypt before rendering so the API key field can be populated
     // synchronously inside the Obsidian Settings builder callbacks.
-    const decryptedApiKey = this.plugin.settings.apiKeyEncrypted
-      ? await this.plugin.secrets.decrypt(this.plugin.settings.apiKeyEncrypted)
-      : '';
+    let decryptedApiKey = '';
+    if (this.plugin.settings.apiKeyEncrypted) {
+      try {
+        decryptedApiKey = await this.plugin.secrets.decrypt(this.plugin.settings.apiKeyEncrypted);
+      } catch {
+        new Notice('Failed to decrypt the stored API key. Re-enter it to continue.');
+      }
+    }
 
     // On mobile, local providers that require a server on the same machine
     // are not reachable. Filter them out so users cannot accidentally select
@@ -101,9 +107,12 @@ export class CurraintSettingTab extends PluginSettingTab {
             .setPlaceholder('sk-...')
             .setValue(decryptedApiKey)
             .onChange(async (value) => {
-              this.plugin.settings.apiKeyEncrypted = value
+              const requestId = ++this.apiKeyRequestId;
+              const encrypted = value
                 ? await this.plugin.secrets.encrypt(value.trim())
                 : '';
+              if (requestId !== this.apiKeyRequestId) return;
+              this.plugin.settings.apiKeyEncrypted = encrypted;
               await this.plugin.saveSettings();
             });
         });

--- a/packages/obsidian-plugin/src/settings-tab.ts
+++ b/packages/obsidian-plugin/src/settings-tab.ts
@@ -132,11 +132,16 @@ export class CurraintSettingTab extends PluginSettingTab {
         text
           .setValue(String(this.plugin.settings.contextMaxMessages))
           .onChange(async (value) => {
-            const num = parseInt(value, 10);
-            if (!isNaN(num) && num >= 4 && num <= 120) {
-              this.plugin.settings.contextMaxMessages = num;
-              await this.plugin.saveSettings();
+            const previousValue = this.plugin.settings.contextMaxMessages;
+            if (value === String(previousValue)) return;
+            const num = Number.parseInt(value, 10);
+            if (Number.isNaN(num) || num < 4 || num > 120) {
+              new Notice('Max messages must be between 4 and 120.');
+              text.setValue(String(previousValue));
+              return;
             }
+            this.plugin.settings.contextMaxMessages = num;
+            await this.plugin.saveSettings();
           })
       );
 
@@ -147,11 +152,16 @@ export class CurraintSettingTab extends PluginSettingTab {
         text
           .setValue(String(this.plugin.settings.contextMaxCharacters))
           .onChange(async (value) => {
-            const num = parseInt(value, 10);
-            if (!isNaN(num) && num >= 4000 && num <= 200000) {
-              this.plugin.settings.contextMaxCharacters = num;
-              await this.plugin.saveSettings();
+            const previousValue = this.plugin.settings.contextMaxCharacters;
+            if (value === String(previousValue)) return;
+            const num = Number.parseInt(value, 10);
+            if (Number.isNaN(num) || num < 4000 || num > 200000) {
+              new Notice('Max characters must be between 4000 and 200000.');
+              text.setValue(String(previousValue));
+              return;
             }
+            this.plugin.settings.contextMaxCharacters = num;
+            await this.plugin.saveSettings();
           })
       );
   }

--- a/packages/obsidian-plugin/src/transport.stream.test.ts
+++ b/packages/obsidian-plugin/src/transport.stream.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { requestUrl, chatCompletionStream, composeConversation } = vi.hoisted(() => ({
+  requestUrl: vi.fn(),
+  chatCompletionStream: vi.fn(),
+  composeConversation: vi.fn(),
+}));
+
+vi.mock('obsidian', () => ({
+  requestUrl,
+  Platform: { isMobile: false },
+}));
+
+vi.mock('@curraint/core', () => ({
+  chatCompletionStream,
+  composeConversation,
+}));
+
+import { buildTransport } from './transport';
+
+describe('buildTransport abort handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    composeConversation.mockImplementation((_settings, messages) => messages);
+  });
+
+  it('does not start the non-streaming fallback when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    chatCompletionStream.mockRejectedValueOnce(new Error('stream failed'));
+
+    const transport = buildTransport({
+      settings: {
+        provider: 'openai',
+        apiKeyEncrypted: '',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o-mini',
+        systemPrompt: '',
+        contextMaxMessages: 40,
+        contextMaxCharacters: 24000,
+        enableSessionSaving: false,
+      },
+      secrets: { decrypt: vi.fn() },
+    } as never);
+
+    const onDelta = vi.fn();
+    const result = await transport.streamChat(
+      [{ role: 'user', content: 'Hello' }],
+      onDelta,
+      { signal: controller.signal }
+    );
+
+    expect(result).toEqual({ text: '' });
+    expect(requestUrl).not.toHaveBeenCalled();
+    expect(onDelta).not.toHaveBeenCalled();
+  });
+
+  it('drops the non-streaming fallback result when the signal aborts while waiting', async () => {
+    const controller = new AbortController();
+    chatCompletionStream.mockRejectedValueOnce(new Error('stream failed'));
+    requestUrl.mockImplementationOnce(async () => {
+      controller.abort();
+      return {
+        status: 200,
+        json: {
+          choices: [{ message: { content: 'Fallback response' } }],
+        },
+        text: '',
+      };
+    });
+
+    const transport = buildTransport({
+      settings: {
+        provider: 'openai',
+        apiKeyEncrypted: '',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o-mini',
+        systemPrompt: '',
+        contextMaxMessages: 40,
+        contextMaxCharacters: 24000,
+        enableSessionSaving: false,
+      },
+      secrets: { decrypt: vi.fn() },
+    } as never);
+
+    const onDelta = vi.fn();
+    const result = await transport.streamChat(
+      [{ role: 'user', content: 'Hello' }],
+      onDelta,
+      { signal: controller.signal }
+    );
+
+    expect(result).toEqual({ text: '' });
+    expect(requestUrl).toHaveBeenCalledTimes(1);
+    expect(onDelta).not.toHaveBeenCalled();
+  });
+});

--- a/packages/obsidian-plugin/src/transport.stream.test.ts
+++ b/packages/obsidian-plugin/src/transport.stream.test.ts
@@ -17,6 +17,7 @@ vi.mock('@curraint/core', () => ({
 }));
 
 import { buildTransport } from './transport';
+import type CurraintPlugin from './main';
 
 describe('buildTransport abort handling', () => {
   beforeEach(() => {
@@ -29,7 +30,7 @@ describe('buildTransport abort handling', () => {
     controller.abort();
     chatCompletionStream.mockRejectedValueOnce(new Error('stream failed'));
 
-    const transport = buildTransport({
+    const plugin = {
       settings: {
         provider: 'openai',
         apiKeyEncrypted: '',
@@ -39,9 +40,12 @@ describe('buildTransport abort handling', () => {
         contextMaxMessages: 40,
         contextMaxCharacters: 24000,
         enableSessionSaving: false,
+        mobileDeviceKey: '',
       },
-      secrets: { decrypt: vi.fn() },
-    } as never);
+      secrets: { decrypt: vi.fn(), encrypt: vi.fn() },
+    } satisfies Pick<CurraintPlugin, 'settings' | 'secrets'>;
+
+    const transport = buildTransport(plugin);
 
     const onDelta = vi.fn();
     const result = await transport.streamChat(
@@ -69,7 +73,7 @@ describe('buildTransport abort handling', () => {
       };
     });
 
-    const transport = buildTransport({
+    const plugin = {
       settings: {
         provider: 'openai',
         apiKeyEncrypted: '',
@@ -79,9 +83,12 @@ describe('buildTransport abort handling', () => {
         contextMaxMessages: 40,
         contextMaxCharacters: 24000,
         enableSessionSaving: false,
+        mobileDeviceKey: '',
       },
-      secrets: { decrypt: vi.fn() },
-    } as never);
+      secrets: { decrypt: vi.fn(), encrypt: vi.fn() },
+    } satisfies Pick<CurraintPlugin, 'settings' | 'secrets'>;
+
+    const transport = buildTransport(plugin);
 
     const onDelta = vi.fn();
     const result = await transport.streamChat(

--- a/packages/obsidian-plugin/src/transport.test.ts
+++ b/packages/obsidian-plugin/src/transport.test.ts
@@ -65,6 +65,12 @@ describe('buildCompletionsUrl', () => {
       'https://api.openai.com/v1/chat/completions'
     );
   });
+
+  it('does not double /v1 when the base URL already ends with /v1/', () => {
+    expect(buildCompletionsUrl('https://api.openai.com/v1/')).toBe(
+      'https://api.openai.com/v1/chat/completions'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/obsidian-plugin/src/transport.test.ts
+++ b/packages/obsidian-plugin/src/transport.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLmsUrl,
+  buildCompletionsUrl,
+  resolveEffectiveLmsSettings,
+} from './transport';
+import type { EndpointSettings } from '@curraint/core';
+
+// Minimal EndpointSettings factory - only fields used by the tested functions.
+function makeSettings(overrides: Partial<EndpointSettings> = {}): EndpointSettings {
+  return {
+    provider: 'lmstudio',
+    apiKey: '',
+    baseUrl: 'http://localhost:1234',
+    model: 'qwen2.5-7b',
+    systemPrompt: '',
+    contextMaxMessages: 40,
+    contextMaxCharacters: 80000,
+    enableSessionSaving: false,
+    ...overrides,
+  } as EndpointSettings;
+}
+
+// ---------------------------------------------------------------------------
+// buildLmsUrl
+// ---------------------------------------------------------------------------
+
+describe('buildLmsUrl', () => {
+  it('appends /api/v1/chat to a plain base URL', () => {
+    expect(buildLmsUrl('http://localhost:1234')).toBe('http://localhost:1234/api/v1/chat');
+  });
+
+  it('strips a trailing slash before appending the path', () => {
+    expect(buildLmsUrl('http://localhost:1234/')).toBe('http://localhost:1234/api/v1/chat');
+  });
+
+  it('strips a trailing /v1 suffix left over from old default URLs', () => {
+    expect(buildLmsUrl('http://localhost:1234/v1')).toBe('http://localhost:1234/api/v1/chat');
+  });
+
+  it('strips /v1/ (with trailing slash) as well', () => {
+    expect(buildLmsUrl('http://localhost:1234/v1/')).toBe('http://localhost:1234/api/v1/chat');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCompletionsUrl
+// ---------------------------------------------------------------------------
+
+describe('buildCompletionsUrl', () => {
+  it('appends /v1/chat/completions to a plain base URL', () => {
+    expect(buildCompletionsUrl('http://localhost:11434')).toBe(
+      'http://localhost:11434/v1/chat/completions'
+    );
+  });
+
+  it('strips a trailing slash before appending the path', () => {
+    expect(buildCompletionsUrl('http://localhost:11434/')).toBe(
+      'http://localhost:11434/v1/chat/completions'
+    );
+  });
+
+  it('does not double /v1 when the base URL already ends with /v1', () => {
+    expect(buildCompletionsUrl('https://api.openai.com/v1')).toBe(
+      'https://api.openai.com/v1/chat/completions'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveLmsSettings
+// ---------------------------------------------------------------------------
+
+describe('resolveEffectiveLmsSettings', () => {
+  it('returns the same settings object when there are no system messages', () => {
+    const settings = makeSettings({ systemPrompt: 'You are helpful.' });
+    const messages = [{ role: 'user', content: 'Hello' }];
+    expect(resolveEffectiveLmsSettings(settings, messages)).toBe(settings);
+  });
+
+  it('merges a single conversation system message with the static system prompt', () => {
+    const settings = makeSettings({ systemPrompt: 'You are helpful.' });
+    const messages = [
+      { role: 'system', content: 'Note context: foo' },
+      { role: 'user', content: 'Hello' },
+    ];
+    const result = resolveEffectiveLmsSettings(settings, messages);
+    expect(result).not.toBe(settings);
+    expect(result.systemPrompt).toBe('You are helpful.\n\nNote context: foo');
+  });
+
+  it('uses only the conversation system message when the static prompt is empty', () => {
+    const settings = makeSettings({ systemPrompt: '' });
+    const messages = [{ role: 'system', content: 'Note context: bar' }];
+    const result = resolveEffectiveLmsSettings(settings, messages);
+    expect(result.systemPrompt).toBe('Note context: bar');
+  });
+
+  it('does not mutate the original settings object', () => {
+    const settings = makeSettings({ systemPrompt: 'Original' });
+    const messages = [{ role: 'system', content: 'Injected context' }];
+    resolveEffectiveLmsSettings(settings, messages);
+    expect(settings.systemPrompt).toBe('Original');
+  });
+
+  it('merges multiple conversation system messages in order', () => {
+    const settings = makeSettings({ systemPrompt: 'Base' });
+    const messages = [
+      { role: 'system', content: 'First' },
+      { role: 'user', content: 'Hello' },
+      { role: 'system', content: 'Second' },
+    ];
+    const result = resolveEffectiveLmsSettings(settings, messages);
+    expect(result.systemPrompt).toBe('Base\n\nFirst\n\nSecond');
+  });
+
+  it('returns the original settings when the merged prompt equals the existing one', () => {
+    // Edge case: static prompt already contains the same text.
+    const settings = makeSettings({ systemPrompt: 'Same' });
+    const messages = [{ role: 'system', content: 'Same' }];
+    const result = resolveEffectiveLmsSettings(settings, messages);
+    // The merged string 'Same\n\nSame' differs from 'Same' so a new object IS returned.
+    expect(result.systemPrompt).toBe('Same\n\nSame');
+  });
+});

--- a/packages/obsidian-plugin/src/transport.ts
+++ b/packages/obsidian-plugin/src/transport.ts
@@ -1,0 +1,206 @@
+import { requestUrl } from 'obsidian';
+import {
+  chatCompletionStream,
+  composeConversation,
+} from '@curraint/core';
+import type { EndpointSettings, ChatSessionTransport } from '@curraint/core';
+import type CurraintPlugin from './main';
+import { decryptApiKey } from './secrets';
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === 'AbortError') ||
+    (error instanceof Error && error.name === 'AbortError')
+  );
+}
+
+// --- LM Studio native API (/api/v1/chat) ------------------------------------
+
+type LmsOutput = { type: string; content?: string };
+type LmsResponse = {
+  output?: LmsOutput[];
+  response_id?: string;
+  error?: { message?: string };
+};
+
+function buildLmsUrl(baseUrl: string): string {
+  // Strip trailing slash and any /v1 suffix left over from the old default URL.
+  const base = baseUrl.trim().replace(/\/v1\/?$/, '').replace(/\/$/, '');
+  return `${base}/api/v1/chat`;
+}
+
+// Sends a message to LM Studio using its native stateful chat API.
+// Uses Obsidian's requestUrl to bypass CORS preflight restrictions - native
+// fetch triggers an OPTIONS preflight that LM Studio rejects. requestUrl
+// routes through Electron's main process and is not subject to CORS.
+// Passes previous_response_id so the server maintains conversation history.
+async function lmStudioChat(
+  settings: EndpointSettings,
+  lastUserMessage: string,
+  previousResponseId: string | null
+): Promise<{ text: string; responseId: string | null }> {
+  const url = buildLmsUrl(settings.baseUrl);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (settings.apiKey.trim()) headers['Authorization'] = `Bearer ${settings.apiKey.trim()}`;
+
+  const body: Record<string, unknown> = { model: settings.model.trim(), input: lastUserMessage };
+  if (settings.systemPrompt) body.system_prompt = settings.systemPrompt;
+  if (previousResponseId) body.previous_response_id = previousResponseId;
+
+  const res = await requestUrl({ url, method: 'POST', headers, body: JSON.stringify(body), throw: false });
+  if (res.status < 200 || res.status >= 300) {
+    const json = res.json as LmsResponse | undefined;
+    throw new Error(`LM Studio request failed (${res.status}): ${json?.error?.message ?? res.text}`);
+  }
+
+  const json = res.json as LmsResponse;
+  const text = json.output?.find((o) => o.type === 'message')?.content?.trim();
+  if (!text) throw new Error('LM Studio returned an empty response.');
+  return { text, responseId: json.response_id ?? null };
+}
+
+// --- OpenAI-compatible fallback (for openai / custom providers) -------------
+
+function buildCompletionsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/$/, '');
+  const base = trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+  return `${base}/chat/completions`;
+}
+
+// Uses Obsidian's requestUrl to bypass the Chromium CORS preflight that native
+// fetch triggers for cross-origin requests to local servers.
+async function corsFreeChatCompletion(
+  settings: EndpointSettings,
+  messages: { role: string; content: string }[]
+): Promise<string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (settings.apiKey.trim()) headers['Authorization'] = `Bearer ${settings.apiKey.trim()}`;
+  const res = await requestUrl({
+    url: buildCompletionsUrl(settings.baseUrl),
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: settings.model.trim(), messages }),
+    throw: false,
+  });
+  if (res.status < 200 || res.status >= 300) {
+    const detail =
+      (res.json as { error?: { message?: string } } | undefined)?.error?.message ?? res.text;
+    throw new Error(`Request failed (${res.status}): ${detail}`);
+  }
+  const text = (res.json as { choices?: { message?: { content?: string } }[] } | undefined)
+    ?.choices?.[0]?.message?.content?.trim();
+  if (!text) throw new Error('Endpoint returned an empty response.');
+  return text;
+}
+
+// --- LM Studio connection test ---------------------------------------------
+
+export async function testLmStudioConnection(settings: EndpointSettings): Promise<string> {
+  const url = buildLmsUrl(settings.baseUrl);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (settings.apiKey.trim()) headers['Authorization'] = `Bearer ${settings.apiKey.trim()}`;
+  const body = { model: settings.model.trim(), input: 'ping' };
+  const res = await requestUrl({ url, method: 'POST', headers, body: JSON.stringify(body), throw: false });
+  if (res.status < 200 || res.status >= 300) {
+    const json = res.json as LmsResponse | undefined;
+    throw new Error(`Connection test failed (${res.status}): ${json?.error?.message ?? res.text}`);
+  }
+  return 'Connection successful.';
+}
+
+// --- Transport factory -------------------------------------------------------
+
+export function buildTransport(plugin: CurraintPlugin): ChatSessionTransport {
+  // Tracks the LM Studio server-side conversation so the full history does not
+  // need to be re-sent on every turn. Reset when the session is cleared.
+  let lmsResponseId: string | null = null;
+
+  return {
+    streamChat: async (messages, onDelta, options) => {
+      const settings = resolveSettings(plugin);
+
+      // LM Studio native API - stateful, streaming over SSE.
+      // Only use the native API when server-side context exists (lmsResponseId set)
+      // or this is the very first message of a fresh conversation (no prior history).
+      // For sessions loaded from disk, lmsResponseId is null but there IS prior
+      // history - fall through to the OpenAI-compatible path below, which sends
+      // the full message history so the model has correct context.
+      const nonSystemMessages = messages.filter((m) => m.role !== 'system');
+      if (settings.provider === 'lmstudio' && (lmsResponseId !== null || nonSystemMessages.length <= 1)) {
+        const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+        if (!lastUser) throw new Error('No user message to send.');
+
+        // Merge any conversation-level system messages (e.g. note context)
+        // with the static system prompt from settings.
+        const conversationSystemParts = messages
+          .filter((m) => m.role === 'system')
+          .map((m) => m.content);
+        const effectiveSystemPrompt = [settings.systemPrompt, ...conversationSystemParts]
+          .filter(Boolean)
+          .join('\n\n') || undefined;
+
+        const lmsSettings = effectiveSystemPrompt !== settings.systemPrompt
+          ? { ...settings, systemPrompt: effectiveSystemPrompt ?? '' }
+          : settings;
+
+        const { text, responseId } = await lmStudioChat(lmsSettings, lastUser.content, lmsResponseId);
+
+        // requestUrl cannot be aborted - check if Stop was pressed while waiting
+        // and surface it as an AbortError so the core handles it as a cancellation.
+        if (options?.signal?.aborted) {
+          throw new DOMException('Aborted', 'AbortError');
+        }
+
+        lmsResponseId = responseId;
+        onDelta(text);
+        return { text };
+      }
+
+      // OpenAI-compatible providers.
+      const composed = composeConversation(settings, messages);
+      const apiMessages = composed.map(({ role, content }) => ({ role, content }));
+      let hasStreamedChunk = false;
+      let streamedMessage = '';
+
+      try {
+        const result = await chatCompletionStream(
+          settings,
+          composed,
+          {
+            onDelta: (delta) => {
+              hasStreamedChunk = true;
+              streamedMessage += delta;
+              onDelta(delta);
+            },
+          },
+          { signal: options?.signal }
+        );
+        return { text: result.message, usage: result.usage };
+      } catch (error) {
+        if (isAbortError(error)) return { text: streamedMessage };
+        if (hasStreamedChunk) throw error;
+        const text = await corsFreeChatCompletion(settings, apiMessages);
+        onDelta(text);
+        return { text };
+      }
+    },
+
+    clearSession: async () => {
+      lmsResponseId = null;
+    },
+  };
+}
+
+function resolveSettings(plugin: CurraintPlugin): EndpointSettings {
+  const s = plugin.settings;
+  return {
+    provider: s.provider,
+    apiKey: s.apiKeyEncrypted ? decryptApiKey(s.apiKeyEncrypted) : '',
+    baseUrl: s.baseUrl,
+    model: s.model,
+    systemPrompt: s.systemPrompt,
+    contextMaxMessages: s.contextMaxMessages,
+    contextMaxCharacters: s.contextMaxCharacters,
+    enableSessionSaving: s.enableSessionSaving,
+  };
+}

--- a/packages/obsidian-plugin/src/transport.ts
+++ b/packages/obsidian-plugin/src/transport.ts
@@ -7,6 +7,8 @@ import type { EndpointSettings, ChatSessionTransport } from '@curraint/core';
 import type { ChatMessage, TokenUsage } from '@curraint/core';
 import type CurraintPlugin from './main';
 
+type TransportPlugin = Pick<CurraintPlugin, 'settings' | 'secrets'>;
+
 function isAbortError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === 'AbortError') ||
@@ -204,7 +206,7 @@ async function streamOpenAiCompat(
 
 // --- Transport factory -------------------------------------------------------
 
-export function buildTransport(plugin: CurraintPlugin): ChatSessionTransport {
+export function buildTransport(plugin: TransportPlugin): ChatSessionTransport {
   // Tracks the LM Studio server-side conversation so the full history does not
   // need to be re-sent on every turn. Reset when the session is cleared.
   let lmsResponseId: string | null = null;

--- a/packages/obsidian-plugin/src/transport.ts
+++ b/packages/obsidian-plugin/src/transport.ts
@@ -1,11 +1,10 @@
-import { requestUrl } from 'obsidian';
+import { requestUrl, Platform } from 'obsidian';
 import {
   chatCompletionStream,
   composeConversation,
 } from '@curraint/core';
 import type { EndpointSettings, ChatSessionTransport } from '@curraint/core';
 import type CurraintPlugin from './main';
-import { decryptApiKey } from './secrets';
 
 function isAbortError(error: unknown): boolean {
   return (
@@ -23,7 +22,7 @@ type LmsResponse = {
   error?: { message?: string };
 };
 
-function buildLmsUrl(baseUrl: string): string {
+export function buildLmsUrl(baseUrl: string): string {
   // Strip trailing slash and any /v1 suffix left over from the old default URL.
   const base = baseUrl.trim().replace(/\/v1\/?$/, '').replace(/\/$/, '');
   return `${base}/api/v1/chat`;
@@ -61,7 +60,7 @@ async function lmStudioChat(
 
 // --- OpenAI-compatible fallback (for openai / custom providers) -------------
 
-function buildCompletionsUrl(baseUrl: string): string {
+export function buildCompletionsUrl(baseUrl: string): string {
   const trimmed = baseUrl.trim().replace(/\/$/, '');
   const base = trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
   return `${base}/chat/completions`;
@@ -108,6 +107,94 @@ export async function testLmStudioConnection(settings: EndpointSettings): Promis
   return 'Connection successful.';
 }
 
+// --- LM Studio system prompt merge ------------------------------------------
+
+// Merges any conversation-level system messages (e.g. note context injected
+// per-turn) with the static system prompt from settings, returning a settings
+// object with the combined prompt. Returns the original settings unchanged
+// when no merge is needed.
+export function resolveEffectiveLmsSettings(
+  settings: EndpointSettings,
+  messages: { role: string; content: string }[]
+): EndpointSettings {
+  const conversationSystemParts = messages
+    .filter((m) => m.role === 'system')
+    .map((m) => m.content);
+  if (conversationSystemParts.length === 0) return settings;
+  const effectiveSystemPrompt =
+    [settings.systemPrompt, ...conversationSystemParts].filter(Boolean).join('\n\n') || undefined;
+  return effectiveSystemPrompt !== settings.systemPrompt
+    ? { ...settings, systemPrompt: effectiveSystemPrompt ?? '' }
+    : settings;
+}
+
+// --- LM Studio stream --------------------------------------------------------
+
+// Sends a single turn to LM Studio using its native stateful API and calls
+// onDelta with the full response text. Returns the updated response ID so the
+// caller can thread subsequent turns through the server-side conversation.
+async function streamLmStudio(
+  settings: EndpointSettings,
+  messages: { role: string; content: string }[],
+  onDelta: (delta: string) => void,
+  lmsResponseId: string | null,
+  signal?: AbortSignal
+): Promise<{ text: string; responseId: string | null }> {
+  const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+  if (!lastUser) throw new Error('No user message to send.');
+
+  const lmsSettings = resolveEffectiveLmsSettings(settings, messages);
+  const { text, responseId } = await lmStudioChat(lmsSettings, lastUser.content, lmsResponseId);
+
+  // requestUrl cannot be aborted - check if Stop was pressed while waiting
+  // and surface it as an AbortError so the core handles it as a cancellation.
+  if (signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
+
+  onDelta(text);
+  return { text, responseId };
+}
+
+// --- OpenAI-compatible stream ------------------------------------------------
+
+// Streams a chat completion using the OpenAI-compatible API. Falls back to a
+// single non-streaming requestUrl call if SSE streaming fails before any
+// chunks arrive (e.g. providers that do not support streaming in all configs).
+async function streamOpenAiCompat(
+  settings: EndpointSettings,
+  messages: { role: string; content: string }[],
+  onDelta: (delta: string) => void,
+  signal?: AbortSignal
+): Promise<{ text: string; usage?: unknown }> {
+  const composed = composeConversation(settings, messages);
+  const apiMessages = composed.map(({ role, content }) => ({ role, content }));
+  let hasStreamedChunk = false;
+  let streamedMessage = '';
+
+  try {
+    const result = await chatCompletionStream(
+      settings,
+      composed,
+      {
+        onDelta: (delta) => {
+          hasStreamedChunk = true;
+          streamedMessage += delta;
+          onDelta(delta);
+        },
+      },
+      { signal }
+    );
+    return { text: result.message, usage: result.usage };
+  } catch (error) {
+    if (isAbortError(error)) return { text: streamedMessage };
+    if (hasStreamedChunk) throw error;
+    const text = await corsFreeChatCompletion(settings, apiMessages);
+    onDelta(text);
+    return { text };
+  }
+}
+
 // --- Transport factory -------------------------------------------------------
 
 export function buildTransport(plugin: CurraintPlugin): ChatSessionTransport {
@@ -115,92 +202,60 @@ export function buildTransport(plugin: CurraintPlugin): ChatSessionTransport {
   // need to be re-sent on every turn. Reset when the session is cleared.
   let lmsResponseId: string | null = null;
 
+  // Cache the last-decrypted API key so PBKDF2 and AES-GCM do not run on
+  // every message send. Invalidated automatically when the encrypted value
+  // changes (i.e. when the user updates their key in settings).
+  let cachedEncrypted: string | null = null;
+  let cachedApiKey = '';
+
+  async function resolveSettings(): Promise<EndpointSettings> {
+    const s = plugin.settings;
+    if (s.apiKeyEncrypted !== cachedEncrypted) {
+      cachedApiKey = s.apiKeyEncrypted ? await plugin.secrets.decrypt(s.apiKeyEncrypted) : '';
+      cachedEncrypted = s.apiKeyEncrypted;
+    }
+    return {
+      provider: s.provider,
+      apiKey: cachedApiKey,
+      baseUrl: s.baseUrl,
+      model: s.model,
+      systemPrompt: s.systemPrompt,
+      contextMaxMessages: s.contextMaxMessages,
+      contextMaxCharacters: s.contextMaxCharacters,
+      enableSessionSaving: s.enableSessionSaving,
+    };
+  }
+
   return {
     streamChat: async (messages, onDelta, options) => {
-      const settings = resolveSettings(plugin);
+      const settings = await resolveSettings();
 
-      // LM Studio native API - stateful, streaming over SSE.
-      // Only use the native API when server-side context exists (lmsResponseId set)
-      // or this is the very first message of a fresh conversation (no prior history).
-      // For sessions loaded from disk, lmsResponseId is null but there IS prior
-      // history - fall through to the OpenAI-compatible path below, which sends
-      // the full message history so the model has correct context.
+      // LM Studio requires a local server - it is not reachable on mobile.
+      if (settings.provider === 'lmstudio' && Platform.isMobile) {
+        throw new Error(
+          'LM Studio is not available on mobile. Switch to a cloud provider in Settings.'
+        );
+      }
+
+      // LM Studio native API - stateful, no full-history re-send.
+      // Only use the native API when server-side context exists (lmsResponseId
+      // set) or this is the very first message of a fresh conversation.
+      // For sessions loaded from disk, lmsResponseId is null but prior history
+      // exists - fall through to OpenAI-compatible path to send full history.
       const nonSystemMessages = messages.filter((m) => m.role !== 'system');
       if (settings.provider === 'lmstudio' && (lmsResponseId !== null || nonSystemMessages.length <= 1)) {
-        const lastUser = [...messages].reverse().find((m) => m.role === 'user');
-        if (!lastUser) throw new Error('No user message to send.');
-
-        // Merge any conversation-level system messages (e.g. note context)
-        // with the static system prompt from settings.
-        const conversationSystemParts = messages
-          .filter((m) => m.role === 'system')
-          .map((m) => m.content);
-        const effectiveSystemPrompt = [settings.systemPrompt, ...conversationSystemParts]
-          .filter(Boolean)
-          .join('\n\n') || undefined;
-
-        const lmsSettings = effectiveSystemPrompt !== settings.systemPrompt
-          ? { ...settings, systemPrompt: effectiveSystemPrompt ?? '' }
-          : settings;
-
-        const { text, responseId } = await lmStudioChat(lmsSettings, lastUser.content, lmsResponseId);
-
-        // requestUrl cannot be aborted - check if Stop was pressed while waiting
-        // and surface it as an AbortError so the core handles it as a cancellation.
-        if (options?.signal?.aborted) {
-          throw new DOMException('Aborted', 'AbortError');
-        }
-
-        lmsResponseId = responseId;
-        onDelta(text);
-        return { text };
-      }
-
-      // OpenAI-compatible providers.
-      const composed = composeConversation(settings, messages);
-      const apiMessages = composed.map(({ role, content }) => ({ role, content }));
-      let hasStreamedChunk = false;
-      let streamedMessage = '';
-
-      try {
-        const result = await chatCompletionStream(
-          settings,
-          composed,
-          {
-            onDelta: (delta) => {
-              hasStreamedChunk = true;
-              streamedMessage += delta;
-              onDelta(delta);
-            },
-          },
-          { signal: options?.signal }
+        const { text, responseId } = await streamLmStudio(
+          settings, messages, onDelta, lmsResponseId, options?.signal
         );
-        return { text: result.message, usage: result.usage };
-      } catch (error) {
-        if (isAbortError(error)) return { text: streamedMessage };
-        if (hasStreamedChunk) throw error;
-        const text = await corsFreeChatCompletion(settings, apiMessages);
-        onDelta(text);
+        lmsResponseId = responseId;
         return { text };
       }
+
+      return streamOpenAiCompat(settings, messages, onDelta, options?.signal);
     },
 
     clearSession: async () => {
       lmsResponseId = null;
     },
-  };
-}
-
-function resolveSettings(plugin: CurraintPlugin): EndpointSettings {
-  const s = plugin.settings;
-  return {
-    provider: s.provider,
-    apiKey: s.apiKeyEncrypted ? decryptApiKey(s.apiKeyEncrypted) : '',
-    baseUrl: s.baseUrl,
-    model: s.model,
-    systemPrompt: s.systemPrompt,
-    contextMaxMessages: s.contextMaxMessages,
-    contextMaxCharacters: s.contextMaxCharacters,
-    enableSessionSaving: s.enableSessionSaving,
   };
 }

--- a/packages/obsidian-plugin/src/transport.ts
+++ b/packages/obsidian-plugin/src/transport.ts
@@ -123,9 +123,9 @@ export function resolveEffectiveLmsSettings(
   if (conversationSystemParts.length === 0) return settings;
   const effectiveSystemPrompt =
     [settings.systemPrompt, ...conversationSystemParts].filter(Boolean).join('\n\n') || undefined;
-  return effectiveSystemPrompt !== settings.systemPrompt
-    ? { ...settings, systemPrompt: effectiveSystemPrompt ?? '' }
-    : settings;
+  return effectiveSystemPrompt === settings.systemPrompt
+    ? settings
+    : { ...settings, systemPrompt: effectiveSystemPrompt ?? '' };
 }
 
 // --- LM Studio stream --------------------------------------------------------

--- a/packages/obsidian-plugin/src/transport.ts
+++ b/packages/obsidian-plugin/src/transport.ts
@@ -4,6 +4,7 @@ import {
   composeConversation,
 } from '@curraint/core';
 import type { EndpointSettings, ChatSessionTransport } from '@curraint/core';
+import type { ChatMessage, TokenUsage } from '@curraint/core';
 import type CurraintPlugin from './main';
 
 function isAbortError(error: unknown): boolean {
@@ -163,10 +164,10 @@ async function streamLmStudio(
 // chunks arrive (e.g. providers that do not support streaming in all configs).
 async function streamOpenAiCompat(
   settings: EndpointSettings,
-  messages: { role: string; content: string }[],
+  messages: ChatMessage[],
   onDelta: (delta: string) => void,
   signal?: AbortSignal
-): Promise<{ text: string; usage?: unknown }> {
+): Promise<{ text: string; usage?: TokenUsage }> {
   const composed = composeConversation(settings, messages);
   const apiMessages = composed.map(({ role, content }) => ({ role, content }));
   let hasStreamedChunk = false;
@@ -189,7 +190,13 @@ async function streamOpenAiCompat(
   } catch (error) {
     if (isAbortError(error)) return { text: streamedMessage };
     if (hasStreamedChunk) throw error;
+
+    if (signal?.aborted) return { text: streamedMessage };
+
     const text = await corsFreeChatCompletion(settings, apiMessages);
+
+    if (signal?.aborted) return { text: streamedMessage };
+
     onDelta(text);
     return { text };
   }

--- a/packages/obsidian-plugin/src/types.ts
+++ b/packages/obsidian-plugin/src/types.ts
@@ -1,5 +1,7 @@
 import type { ProviderId } from '@curraint/core';
 
+declare const __DEV__: boolean;
+
 export type PluginSettings = {
   provider: ProviderId;
   apiKeyEncrypted: string;
@@ -9,4 +11,8 @@ export type PluginSettings = {
   contextMaxMessages: number;
   contextMaxCharacters: number;
   enableSessionSaving: boolean;
+  // Random 32-byte key (base64) generated on first mobile run.
+  // Used by MobileSecretsStrategy to encrypt the API key with Web Crypto.
+  // Empty on desktop - the DesktopSecretsStrategy uses a machine-derived key.
+  mobileDeviceKey: string;
 };

--- a/packages/obsidian-plugin/src/types.ts
+++ b/packages/obsidian-plugin/src/types.ts
@@ -1,0 +1,12 @@
+import type { ProviderId } from '@curraint/core';
+
+export type PluginSettings = {
+  provider: ProviderId;
+  apiKeyEncrypted: string;
+  baseUrl: string;
+  model: string;
+  systemPrompt: string;
+  contextMaxMessages: number;
+  contextMaxCharacters: number;
+  enableSessionSaving: boolean;
+};

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -180,6 +180,16 @@
   width: 100%;
 }
 
+.curraint-message__content[data-markdown-render-failed='true'] {
+  white-space: pre-wrap;
+}
+
+.curraint-message__render-warning {
+  margin-top: 6px;
+  font-size: 0.85em;
+  color: var(--text-warning);
+}
+
 .curraint-message--assistant .curraint-message__content th,
 .curraint-message--assistant .curraint-message__content td {
   border: 1px solid var(--background-modifier-border);
@@ -291,8 +301,10 @@
 }
 
 .curraint-input-bar__textarea:focus {
-  outline: none;
   border-color: var(--interactive-accent);
+  outline: 2px solid var(--background-modifier-border-focus, var(--interactive-accent));
+  outline-offset: 2px;
+  box-shadow: 0 0 0 1px var(--background-secondary);
 }
 
 .curraint-input-bar__stop {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -14,13 +14,19 @@
 
 .curraint-chat-header {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
   padding: 4px 8px;
   border-bottom: 1px solid var(--background-modifier-border);
   background-color: var(--background-primary);
   flex-shrink: 0;
+  gap: 2px;
+}
+
+.curraint-chat-header__controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
 }
 
 .curraint-chat-header__new-chat,
@@ -99,6 +105,24 @@
   align-self: flex-end;
   max-width: 80%;
   white-space: pre-wrap;
+}
+
+.curraint-message__note-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.curraint-message__note-tag {
+  font-size: 0.72em;
+  opacity: 0.85;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 10px;
+  padding: 1px 7px;
+  white-space: nowrap;
 }
 
 .curraint-message--assistant {
@@ -187,6 +211,7 @@
 .curraint-context-bar {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
   padding: 6px 12px 0;
 }
@@ -311,15 +336,45 @@
   border-color: var(--interactive-accent);
 }
 
-.curraint-input-bar__note-add {
-  padding: 4px 8px;
+.curraint-input-bar__add-current-note {
+  height: 24px;
+  padding: 0 8px;
+  flex-shrink: 0;
   border-radius: 12px;
   border: 1px dashed var(--background-modifier-border);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
   white-space: nowrap;
-  font-size: 0.8em;
+  font-size: 0.75em;
+}
+
+.curraint-input-bar__add-current-note:hover {
+  border-color: var(--interactive-accent);
+  color: var(--interactive-accent);
+}
+
+.curraint-input-bar__add-current-note:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ---- Bottom bar (browse notes) ---------------------------- */
+
+.curraint-input-bottom-bar {
+  padding: 0 12px 8px;
+}
+
+.curraint-input-bar__note-add {
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 12px;
+  border: 1px dashed var(--background-modifier-border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 0.75em;
 }
 
 .curraint-input-bar__note-add:hover {
@@ -327,7 +382,334 @@
   color: var(--interactive-accent);
 }
 
+.curraint-input-bar__note-add:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .curraint-input-bar__textarea:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* ---- Header title input ----------------------------------- */
+
+.curraint-chat-header__title {
+  width: 100%;
+  box-sizing: border-box;
+  background: none;
+  border: none;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  color: var(--text-normal);
+  font-size: 0.82em;
+  font-weight: 500;
+  padding: 1px 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: text;
+  box-shadow: none;
+  outline: none;
+}
+
+.curraint-chat-header__title::placeholder {
+  color: var(--text-faint);
+  font-weight: 400;
+}
+
+.curraint-chat-header__title:hover {
+  border-bottom-color: var(--background-modifier-border);
+}
+
+.curraint-chat-header__title:focus {
+  border-bottom-color: var(--interactive-accent);
+  outline: none;
+  box-shadow: none;
+}
+
+/* ---- Sessions modal --------------------------------------- */
+
+.curraint-sessions-modal .modal-content {
+  max-width: 540px;
+}
+
+.curraint-sessions-modal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.curraint-sessions-modal__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.curraint-sessions-modal__item:last-child {
+  border-bottom: none;
+}
+
+.curraint-sessions-modal__meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.curraint-sessions-modal__title-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.curraint-sessions-modal__title {
+  font-size: 0.9em;
+  font-weight: 500;
+  color: var(--text-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.curraint-sessions-modal__info {
+  display: block;
+  font-size: 0.78em;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.curraint-sessions-modal__rename {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-faint);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.curraint-sessions-modal__rename svg {
+  width: 11px;
+  height: 11px;
+}
+
+.curraint-sessions-modal__item:hover .curraint-sessions-modal__rename {
+  opacity: 1;
+}
+
+.curraint-sessions-modal__rename:hover {
+  color: var(--interactive-accent);
+}
+
+.curraint-sessions-modal__rename-input {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9em;
+  font-weight: 500;
+  padding: 1px 4px;
+  border-radius: 3px;
+  border: 1px solid var(--interactive-accent);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  box-shadow: none;
+  outline: none;
+}
+
+.curraint-sessions-modal__rename-input:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.curraint-sessions-modal__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.curraint-sessions-modal__open,
+.curraint-sessions-modal__delete {
+  font-size: 0.82em;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.curraint-sessions-modal__delete {
+  background: none;
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.curraint-sessions-modal__delete:hover {
+  border-color: var(--text-error);
+  color: var(--text-error);
+}
+
+.curraint-sessions-modal__empty {
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+/* ---- Delete confirmation modal ---------------------------- */
+
+.curraint-delete-confirm-modal__message {
+  margin: 0 0 16px;
+  font-size: 0.95em;
+  color: var(--text-normal);
+}
+
+.curraint-delete-confirm-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.curraint-delete-confirm-modal__cancel,
+.curraint-delete-confirm-modal__confirm {
+  font-size: 0.88em;
+  padding: 4px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.curraint-delete-confirm-modal__cancel {
+  background: none;
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.curraint-delete-confirm-modal__cancel:hover {
+  border-color: var(--text-normal);
+  color: var(--text-normal);
+}
+
+/* ---- Note picker modal ------------------------------------ */
+
+.curraint-note-picker-modal .modal-content {
+  max-width: 480px;
+}
+
+.curraint-note-picker-modal__search {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-secondary);
+  color: var(--text-normal);
+  font-family: inherit;
+  font-size: 0.9em;
+}
+
+.curraint-note-picker-modal__search:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+}
+
+.curraint-note-picker-modal__list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+}
+
+.curraint-note-picker-modal__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.1s;
+}
+
+.curraint-note-picker-modal__item:last-child {
+  border-bottom: none;
+}
+
+.curraint-note-picker-modal__item:hover {
+  background-color: var(--background-modifier-hover);
+}
+
+.curraint-note-picker-modal__item.is-checked {
+  background-color: var(--background-secondary-alt);
+}
+
+.curraint-note-picker-modal__checkbox {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.curraint-note-picker-modal__label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.curraint-note-picker-modal__basename {
+  font-size: 0.88em;
+  color: var(--text-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.curraint-note-picker-modal__folder {
+  font-size: 0.76em;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.curraint-note-picker-modal__overflow,
+.curraint-note-picker-modal__empty {
+  padding: 8px 10px;
+  font-size: 0.82em;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.curraint-note-picker-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.curraint-note-picker-modal__cancel,
+.curraint-note-picker-modal__confirm {
+  font-size: 0.88em;
+  padding: 4px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.curraint-note-picker-modal__cancel {
+  background: none;
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.curraint-note-picker-modal__cancel:hover {
+  border-color: var(--text-normal);
+  color: var(--text-normal);
 }

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -93,7 +93,7 @@
   padding: 8px 12px;
   border-radius: 6px;
   line-height: 1.5;
-  word-break: break-word;
+  overflow-wrap: break-word;
   -webkit-user-select: text;
   user-select: text;
   cursor: text;

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -1,0 +1,333 @@
+/* ============================================================
+   Curraint Chat View
+   ============================================================ */
+
+.curraint-chat-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  padding-bottom: var(--size-4-8, 32px);
+}
+
+/* ---- Header bar ------------------------------------------- */
+
+.curraint-chat-header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background-color: var(--background-primary);
+  flex-shrink: 0;
+}
+
+.curraint-chat-header__new-chat,
+.curraint-chat-header__sessions {
+  background: none;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.75em;
+  line-height: 1;
+  padding: 2px 8px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.curraint-chat-header__new-chat:hover,
+.curraint-chat-header__sessions:hover {
+  border-color: var(--interactive-accent);
+  color: var(--interactive-accent);
+}
+
+.curraint-chat-header__format-toggle {
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.curraint-chat-header__format-toggle svg {
+  width: 14px;
+  height: 14px;
+}
+
+.curraint-chat-header__format-toggle:hover {
+  color: var(--text-normal);
+}
+
+.curraint-chat-header__format-toggle.is-active {
+  color: var(--text-normal);
+}
+
+/* ---- Message list ----------------------------------------- */
+
+.curraint-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.curraint-message {
+  max-width: 100%;
+  padding: 8px 12px;
+  border-radius: 6px;
+  line-height: 1.5;
+  word-break: break-word;
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
+}
+
+.curraint-message--user {
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+  align-self: flex-end;
+  max-width: 80%;
+  white-space: pre-wrap;
+}
+
+.curraint-message--assistant {
+  background-color: var(--background-secondary);
+  color: var(--text-normal);
+  align-self: flex-start;
+}
+
+.curraint-message--assistant .curraint-message__content > :first-child {
+  margin-top: 0;
+}
+
+.curraint-message--assistant .curraint-message__content > :last-child {
+  margin-bottom: 0;
+}
+
+.curraint-message--assistant .curraint-message__content pre {
+  background-color: var(--code-background);
+  border-radius: 4px;
+  overflow-x: auto;
+  padding: 8px 10px;
+  margin: 6px 0;
+}
+
+.curraint-message--assistant .curraint-message__content code:not(pre code) {
+  background-color: var(--code-background);
+  border-radius: 3px;
+  font-size: 0.875em;
+  padding: 1px 4px;
+}
+
+.curraint-message--assistant .curraint-message__content ul,
+.curraint-message--assistant .curraint-message__content ol {
+  padding-left: 1.5em;
+  margin: 4px 0;
+}
+
+.curraint-message--assistant .curraint-message__content blockquote {
+  border-left: 3px solid var(--interactive-accent);
+  margin: 6px 0;
+  padding-left: 10px;
+  color: var(--text-muted);
+}
+
+.curraint-message--assistant .curraint-message__content table {
+  border-collapse: collapse;
+  font-size: 0.9em;
+  margin: 6px 0;
+  width: 100%;
+}
+
+.curraint-message--assistant .curraint-message__content th,
+.curraint-message--assistant .curraint-message__content td {
+  border: 1px solid var(--background-modifier-border);
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.curraint-message--streaming::after {
+  content: '▍';
+  animation: curraint-blink 0.7s step-end infinite;
+  margin-left: 2px;
+}
+
+.curraint-message--error {
+  background-color: var(--background-modifier-error);
+  color: var(--text-error);
+  align-self: stretch;
+  font-size: 0.9em;
+}
+
+@keyframes curraint-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ---- Input wrapper (context bar + input row) -------------- */
+
+.curraint-input-wrapper {
+  border-top: 1px solid var(--background-modifier-border);
+  background-color: var(--background-primary);
+}
+
+/* ---- Context chip row ------------------------------------- */
+
+.curraint-context-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 12px 0;
+}
+
+.curraint-note-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 12px;
+  background-color: var(--background-secondary-alt);
+  border: 1px solid var(--background-modifier-border);
+  font-size: 0.8em;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.curraint-note-chip__icon {
+  font-size: 0.9em;
+  line-height: 1;
+}
+
+.curraint-note-chip__label {
+  color: var(--text-normal);
+}
+
+.curraint-note-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1;
+}
+
+.curraint-note-chip__remove:hover {
+  background-color: var(--background-modifier-error);
+  color: var(--text-error);
+}
+
+/* ---- Input bar -------------------------------------------- */
+
+.curraint-input-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 12px;
+}
+
+.curraint-input-bar__textarea {
+  flex: 1;
+  resize: none;
+  min-height: 36px;
+  max-height: 160px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-secondary);
+  color: var(--text-normal);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.4;
+  overflow-y: auto;
+}
+
+.curraint-input-bar__textarea:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+}
+
+.curraint-input-bar__stop {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  width: 32px;
+  flex-shrink: 0;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-secondary);
+  color: var(--text-normal);
+  cursor: pointer;
+}
+
+.curraint-input-bar__stop svg {
+  width: 14px;
+  height: 14px;
+}
+
+.curraint-input-bar__stop:hover {
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: var(--interactive-accent);
+}
+
+.curraint-input-bar__send {
+  height: 32px;
+  padding: 0 10px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-secondary);
+  color: var(--text-normal);
+  cursor: pointer;
+  font-size: 1.1em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.curraint-input-bar__send:hover {
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: var(--interactive-accent);
+}
+
+.curraint-input-bar__note-add {
+  padding: 4px 8px;
+  border-radius: 12px;
+  border: 1px dashed var(--background-modifier-border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 0.8em;
+}
+
+.curraint-input-bar__note-add:hover {
+  border-color: var(--interactive-accent);
+  color: var(--interactive-accent);
+}
+
+.curraint-input-bar__textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -513,6 +513,12 @@
   opacity: 1;
 }
 
+.curraint-sessions-modal__item:focus-within .curraint-sessions-modal__rename,
+.curraint-sessions-modal__rename:focus,
+.curraint-sessions-modal__rename:focus-visible {
+  opacity: 1;
+}
+
 .curraint-sessions-modal__rename:hover {
   color: var(--interactive-accent);
 }

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -99,6 +99,12 @@
   cursor: text;
 }
 
+.curraint-message::selection,
+.curraint-message *::selection {
+  background-color: var(--text-selection, var(--text-highlight-bg));
+  color: inherit;
+}
+
 .curraint-message--user {
   background-color: var(--interactive-accent);
   color: var(--text-on-accent);

--- a/packages/obsidian-plugin/tsconfig.json
+++ b/packages/obsidian-plugin/tsconfig.json
@@ -9,9 +9,10 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "outDir": "dist",
+    "composite": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/*.ts", "src/**/*.ts"],
   "references": [
     { "path": "../core" }
   ]

--- a/packages/obsidian-plugin/tsconfig.json
+++ b/packages/obsidian-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2018", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/obsidian-plugin/vitest.config.ts
+++ b/packages/obsidian-plugin/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      obsidian: path.resolve(__dirname, 'src/__mocks__/obsidian.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+});

--- a/packages/obsidian-plugin/vitest.config.ts
+++ b/packages/obsidian-plugin/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
   },
   test: {
+    // Default to node, but keep jsdom installed for per-file DOM test overrides.
     environment: 'node',
     passWithNoTests: true,
   },

--- a/packages/obsidian-plugin/vitest.config.ts
+++ b/packages/obsidian-plugin/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config';
-import path from 'path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      obsidian: path.resolve(__dirname, 'src/__mocks__/obsidian.ts'),
+      obsidian: path.resolve(dirname, 'src/__mocks__/obsidian.ts'),
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,34 @@ importers:
         specifier: ^5.8.2
         version: 5.9.3
 
+  packages/obsidian-plugin:
+    dependencies:
+      '@curraint/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.19.11
+      builtin-modules:
+        specifier: ^4.0.0
+        version: 4.0.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      obsidian:
+        specifier: ^1.7.7
+        version: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.11)(jsdom@26.1.0)
+
 packages:
 
   7zip-bin@5.2.0:
@@ -173,6 +201,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -274,13 +305,30 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@codemirror/state@6.5.0':
+    resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
+
+  '@codemirror/view@6.38.6':
+    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-calc@3.1.1':
     resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
@@ -289,12 +337,25 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-color-parser@4.0.2':
     resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -304,6 +365,10 @@ packages:
 
   '@csstools/css-syntax-patches-for-csstree@1.0.28':
     resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -874,6 +939,9 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1094,6 +1162,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/codemirror@5.60.8':
+    resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1140,6 +1211,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1403,6 +1477,10 @@ packages:
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
+  builtin-modules@4.0.0:
+    resolution: {integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==}
+    engines: {node: '>=18.20'}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1612,6 +1690,9 @@ packages:
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -1630,12 +1711,20 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   cssstyle@6.0.1:
     resolution: {integrity: sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==}
     engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2064,6 +2153,10 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2228,6 +2321,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -2597,6 +2699,9 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  moment@2.29.4:
+    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2652,6 +2757,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2663,6 +2771,12 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  obsidian@1.12.3:
+    resolution: {integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==}
+    peerDependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2701,6 +2815,9 @@ packages:
 
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -2975,6 +3092,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3129,6 +3249,9 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -3212,8 +3335,15 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.23:
     resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
@@ -3230,9 +3360,17 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -3469,6 +3607,9 @@ packages:
     resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
     engines: {node: '>=14.0.0'}
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -3476,13 +3617,30 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -3511,6 +3669,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -3573,6 +3743,14 @@ snapshots:
   '@acemir/cssom@0.9.31': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -3710,15 +3888,40 @@ snapshots:
     dependencies:
       css-tree: 3.1.0
 
+  '@codemirror/state@6.5.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.38.6':
+    dependencies:
+      '@codemirror/state': 6.5.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@colors/colors@1.5.0':
     optional: true
 
+  '@csstools/color-helpers@5.1.0': {}
+
   '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -3727,11 +3930,17 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
 
@@ -4114,6 +4323,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@marijn/find-cluster-break@1.0.2': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4279,6 +4490,10 @@ snapshots:
       '@types/node': 22.19.11
       '@types/responselike': 1.0.3
 
+  '@types/codemirror@5.60.8':
+    dependencies:
+      '@types/tern': 0.23.9
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4334,6 +4549,10 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.11
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/unist@2.0.11': {}
 
@@ -4669,6 +4888,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builtin-modules@4.0.0: {}
+
   bundle-require@5.1.0(esbuild@0.27.3):
     dependencies:
       esbuild: 0.27.3
@@ -4892,6 +5113,8 @@ snapshots:
       buffer: 5.7.1
     optional: true
 
+  crelt@1.0.6: {}
+
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.6
@@ -4909,6 +5132,11 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   cssstyle@6.0.1:
     dependencies:
       '@asamuzakjp/css-color': 4.1.2
@@ -4917,6 +5145,11 @@ snapshots:
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-urls@7.0.0:
     dependencies:
@@ -5504,6 +5737,10 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.14.1
@@ -5653,6 +5890,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@28.1.0:
     dependencies:
@@ -6242,6 +6506,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  moment@2.29.4: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -6306,12 +6572,21 @@ snapshots:
       gauge: 4.0.4
       set-blocking: 2.0.0
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
 
   object-keys@1.1.1:
     optional: true
+
+  obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
+    dependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@types/codemirror': 5.60.8
+      moment: 2.29.4
 
   once@1.4.0:
     dependencies:
@@ -6362,6 +6637,10 @@ snapshots:
   parse5@5.1.1: {}
 
   parse5@6.0.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -6668,6 +6947,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.58.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6811,6 +7092,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -6927,7 +7210,13 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.23: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.23:
     dependencies:
@@ -6943,9 +7232,17 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.23
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
@@ -7129,6 +7426,42 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
 
+  vitest@2.1.9(@types/node@22.19.11)(jsdom@26.1.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.11)
+      vite-node: 2.1.9(@types/node@22.19.11)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vitest@2.1.9(@types/node@22.19.11)(jsdom@28.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
@@ -7167,6 +7500,8 @@ snapshots:
 
   vscode-jsonrpc@8.2.1: {}
 
+  w3c-keyname@2.2.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -7175,9 +7510,22 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.1: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1:
     dependencies:
@@ -7213,6 +7561,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@github/copilot-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30
+        specifier: ^0.2.0
+        version: 0.2.0
       marked:
         specifier: ^15.0.12
         version: 15.0.12
@@ -56,8 +56,8 @@ importers:
         version: 2.1.9(@types/node@22.19.11)(jsdom@28.1.0)
     optionalDependencies:
       '@github/copilot-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30
+        specifier: ^0.2.0
+        version: 0.2.0
 
   packages/desktop:
     dependencies:
@@ -65,8 +65,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@github/copilot-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30
+        specifier: ^0.2.0
+        version: 0.2.0
       electron-log:
         specifier: ^5.4.3
         version: 5.4.3
@@ -867,48 +867,48 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@github/copilot-darwin-arm64@0.0.420':
-    resolution: {integrity: sha512-sj8Oxcf3oKDbeUotm2gtq5YU1lwCt3QIzbMZioFD/PMLOeqSX/wrecI+c0DDYXKofFhALb0+DxxnWgbEs0mnkQ==}
+  '@github/copilot-darwin-arm64@1.0.11':
+    resolution: {integrity: sha512-wdKimjtbsVeXqMqQSnGpGBPFEYHljxXNuWeH8EIJTNRgFpAsimcivsFgql3Twq4YOp0AxfsH36icG4IEen30mA==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-darwin-x64@0.0.420':
-    resolution: {integrity: sha512-2acA93IqXz1uuz3TVUm0Y7BVrBr0MySh1kQa8LqMILhTsG0YHRMm8ybzTp2HA7Mi1tl5CjqMSk163kkS7OzfUA==}
+  '@github/copilot-darwin-x64@1.0.11':
+    resolution: {integrity: sha512-VeuPv8rzBVGBB8uDwMEhcHBpldoKaq26yZ5YQm+G9Ka5QIF+1DMah8ZNRMVsTeNKkb1ji9G8vcuCsaPbnG3fKg==}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-linux-arm64@0.0.420':
-    resolution: {integrity: sha512-h/IvEryTOYm1HzR2GNq8s2aDtN4lvT4MxldfZuS42CtWJDOfVG2jLLsoHWU1T3QV8j1++PmDgE//HX0JLpLMww==}
+  '@github/copilot-linux-arm64@1.0.11':
+    resolution: {integrity: sha512-/d8p6RlFYKj1Va2hekFIcYNMHWagcEkaxgcllUNXSyQLnmEtXUkaWtz62VKGWE+n/UMkEwCB6vI2xEwPTlUNBQ==}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@github/copilot-linux-x64@0.0.420':
-    resolution: {integrity: sha512-iL2NpZvXIDZ+3lw7sO2fo5T0nKmP5dZbU2gdYcv+SFBm/ONhCxIY5VRX4yN/9VkFaa9ePv5JzCnsl3vZINiDxg==}
+  '@github/copilot-linux-x64@1.0.11':
+    resolution: {integrity: sha512-UujTRO3xkPFC1CybchBbCnaTEAG6JrH0etIst07JvfekMWgvRxbiCHQPpDPSzBCPiBcGu0gba0/IT+vUCORuIw==}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@github/copilot-sdk@0.1.30':
-    resolution: {integrity: sha512-Stg+h8xsPRR0TNGBQfd9laxhJfWZ6DsdpbowcKIZoyKxZvMAbjnY0zyDeOpewJbxWBTJVhBZb5okOq6iaPNMZw==}
+  '@github/copilot-sdk@0.2.0':
+    resolution: {integrity: sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==}
     engines: {node: '>=20.0.0'}
 
-  '@github/copilot-win32-arm64@0.0.420':
-    resolution: {integrity: sha512-Njlc2j9vYSBAL+lC6FIEhQ3C+VxO3xavwKnw0ecVRiNLcGLyPrTdzPfPQOmEjC63gpVCqLabikoDGv8fuLPA2w==}
+  '@github/copilot-win32-arm64@1.0.11':
+    resolution: {integrity: sha512-EOW8HUM+EmnHEZEa+iUMl4pP1+2eZUk2XCbynYiMehwX9sidc4BxEHp2RuxADSzFPTieQEWzgjQmHWrtet8pQg==}
     cpu: [arm64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot-win32-x64@0.0.420':
-    resolution: {integrity: sha512-rZlH35oNehAP2DvQbu4vQFVNeCh/1p3rUjafBYaEY0Nkhx7RmdrYBileL5U3PtRPPRsBPaq3Qp+pVIrGoCDLzQ==}
+  '@github/copilot-win32-x64@1.0.11':
+    resolution: {integrity: sha512-fKGkSNamzs3h9AbmswNvPYJBORCb2Y8CbusijU3C7fT3ohvqnHJwKo5iHhJXLOKZNOpFZgq9YKha410u9sIs6Q==}
     cpu: [x64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot@0.0.420':
-    resolution: {integrity: sha512-UpPuSjxUxQ+j02WjZEFffWf0scLb23LvuGHzMFtaSsweR+P/BdbtDUI5ZDIA6T0tVyyt6+X1/vgfsJiRqd6jig==}
+  '@github/copilot@1.0.11':
+    resolution: {integrity: sha512-cptVopko/tNKEXyBP174yBjHQBEwg6CqaKN2S0M3J+5LEB8u31bLL75ioOPd+5vubqBrA0liyTdcHeZ8UTRbmg==}
     hasBin: true
 
   '@isaacs/cliui@8.0.2':
@@ -4249,38 +4249,38 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
-  '@github/copilot-darwin-arm64@0.0.420':
+  '@github/copilot-darwin-arm64@1.0.11':
     optional: true
 
-  '@github/copilot-darwin-x64@0.0.420':
+  '@github/copilot-darwin-x64@1.0.11':
     optional: true
 
-  '@github/copilot-linux-arm64@0.0.420':
+  '@github/copilot-linux-arm64@1.0.11':
     optional: true
 
-  '@github/copilot-linux-x64@0.0.420':
+  '@github/copilot-linux-x64@1.0.11':
     optional: true
 
-  '@github/copilot-sdk@0.1.30':
+  '@github/copilot-sdk@0.2.0':
     dependencies:
-      '@github/copilot': 0.0.420
+      '@github/copilot': 1.0.11
       vscode-jsonrpc: 8.2.1
       zod: 4.3.6
 
-  '@github/copilot-win32-arm64@0.0.420':
+  '@github/copilot-win32-arm64@1.0.11':
     optional: true
 
-  '@github/copilot-win32-x64@0.0.420':
+  '@github/copilot-win32-x64@1.0.11':
     optional: true
 
-  '@github/copilot@0.0.420':
+  '@github/copilot@1.0.11':
     optionalDependencies:
-      '@github/copilot-darwin-arm64': 0.0.420
-      '@github/copilot-darwin-x64': 0.0.420
-      '@github/copilot-linux-arm64': 0.0.420
-      '@github/copilot-linux-x64': 0.0.420
-      '@github/copilot-win32-arm64': 0.0.420
-      '@github/copilot-win32-x64': 0.0.420
+      '@github/copilot-darwin-arm64': 1.0.11
+      '@github/copilot-darwin-x64': 1.0.11
+      '@github/copilot-linux-arm64': 1.0.11
+      '@github/copilot-linux-x64': 1.0.11
+      '@github/copilot-win32-arm64': 1.0.11
+      '@github/copilot-win32-x64': 1.0.11
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
Add packages/obsidian-plugin as a new monorepo package. The plugin integrates the @curraint/core chat engine into Obsidian, providing:

- Streaming chat sidebar with stop, edit, and regenerate support
- Active-note context injection toggle
- Encrypted API key storage in data.json (AES-256-GCM, machine-bound)
- Provider, model, and system-prompt settings via the settings tab
- Session persistence and a session switcher modal
- Deploy script and VS Code tasks for one-click vault installation

Also fix the OpenAI client to strip non-standard properties from messages before sending to the API. Message objects in the plugin carry extra metadata beyond role/content; forwarding them verbatim caused API errors.

Update AGENTS.md, CONTRIBUTING.md, and README.md with plugin docs and add "obsidian" to the list of recognised commit scopes.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Changes

<!-- List the notable changes per package. Remove sections that do not apply. -->

<!--
### `packages/core`

- 

### `packages/cli`

- 

### `packages/desktop`

- 
-->

## Testing

- [x] Unit tests added / updated
- [x] All existing tests pass (`pnpm test`)
- [x] Manually tested in CLI
- [x] Manually tested in Desktop app