### PR TITLE
fix(ci): prevent e2e teardown timeout on headless Linux

### DIFF
--- a/packages/desktop-e2e/tests/fixtures.ts
+++ b/packages/desktop-e2e/tests/fixtures.ts
@@ -53,15 +53,27 @@ async function showWindow(app: ElectronApplication, urlFragment: string): Promis
   );
 }
 
+const APP_CLOSE_TIMEOUT_MS = 10_000;
+
 async function closeElectronApp(app: ElectronApplication): Promise<void> {
   try {
     const closed = app.waitForEvent('close', { timeout: 5_000 });
-    await app.evaluate(({ app: electronApp }) => {
-      electronApp.quit();
-    });
+    const quitTimeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Timed out waiting for app.quit()')), APP_CLOSE_TIMEOUT_MS),
+    );
+    await Promise.race([
+      app.evaluate(({ app: electronApp }) => {
+        electronApp.quit();
+      }),
+      quitTimeout,
+    ]);
     await closed;
   } catch {
-    await app.close();
+    try {
+      await app.close();
+    } catch {
+      // Process is completely unresponsive; let worker teardown handle it
+    }
   }
 }
 
@@ -73,7 +85,12 @@ export const test = base.extend<ElectronFixtures>({
     try {
       const app = await electronLauncher.launch({
         executablePath: electronExecutable,
-        args: [desktopMain, ...(process.env.CI ? ['--no-sandbox', '--disable-dev-shm-usage'] : [])],
+        args: [
+          desktopMain,
+          ...(process.env.CI
+            ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu']
+            : []),
+        ],
         env: {
           ...process.env,
           NODE_ENV: 'test',


### PR DESCRIPTION
Add --disable-gpu to the Electron launch args in CI to prevent GPU initialisation from blocking the main process when BrowserWindow.show() is called on a hidden window.

Wrap the app.evaluate call inside closeElectronApp with a 10 s timeout so that an unresponsive main process does not hang fixture teardown indefinitely.
ning this PR